### PR TITLE
Sync sitemap lastmod dates with spec entry `updated` field

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,17 +1,79 @@
 // @ts-check
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
 import tailwindcss from '@tailwindcss/vite';
 
+const SITE = 'https://specification.website';
+
+/**
+ * Build a map of canonical URL -> last-modified date, derived from the `updated`
+ * front matter of every spec entry. This is the same source of truth the RSS feed
+ * and the spec pages use, so the sitemap's <lastmod> stays in sync automatically.
+ */
+function buildLastmodMap() {
+  const specDir = fileURLToPath(new URL('./src/content/spec', import.meta.url));
+  /** @type {Map<string, string>} per-URL lastmod (YYYY-MM-DD) */
+  const urls = new Map();
+  /** @type {Map<string, string>} per-category newest lastmod */
+  const byCategory = new Map();
+  let newest = '';
+
+  for (const category of readdirSync(specDir, { withFileTypes: true })) {
+    if (!category.isDirectory()) continue;
+    const catDir = `${specDir}/${category.name}`;
+    for (const file of readdirSync(catDir)) {
+      if (!/\.(md|mdx)$/.test(file)) continue;
+      const raw = readFileSync(`${catDir}/${file}`, 'utf8');
+      const fm = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+      if (!fm) continue;
+      const front = fm[1];
+      if (/^draft:\s*true\s*$/m.test(front)) continue;
+
+      const updated = front.match(/^updated:\s*["']?([0-9]{4}-[0-9]{2}-[0-9]{2})["']?\s*$/m)?.[1];
+      if (!updated) continue;
+      const cat = front.match(/^category:\s*["']?([\w-]+)["']?\s*$/m)?.[1] ?? category.name;
+      const slug =
+        front.match(/^slug:\s*["']?([\w-]+)["']?\s*$/m)?.[1] ?? file.replace(/\.(md|mdx)$/, '');
+
+      urls.set(`${SITE}/spec/${cat}/${slug}/`, updated);
+
+      if (updated > (byCategory.get(cat) ?? '')) byCategory.set(cat, updated);
+      if (updated > newest) newest = updated;
+    }
+  }
+
+  // Category index pages reflect the newest entry they list.
+  for (const [cat, updated] of byCategory) {
+    urls.set(`${SITE}/spec/${cat}/`, updated);
+  }
+  // Surfaces derived from the whole collection track the newest entry overall.
+  if (newest) {
+    for (const path of ['/', '/spec/', '/checklist/']) {
+      urls.set(`${SITE}${path}`, newest);
+    }
+  }
+
+  return urls;
+}
+
+const lastmodByUrl = buildLastmodMap();
+
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://specification.website',
+  site: SITE,
   integrations: [
     mdx(),
     sitemap({
       changefreq: 'weekly',
       priority: 0.7,
+      serialize(item) {
+        const lastmod = lastmodByUrl.get(item.url);
+        if (lastmod) item.lastmod = new Date(`${lastmod}T00:00:00Z`).toISOString();
+        return item;
+      },
     }),
   ],
   vite: {

--- a/src/content/spec/seo/xml-sitemaps.md
+++ b/src/content/spec/seo/xml-sitemaps.md
@@ -58,6 +58,8 @@ Follow the spec:
 
 Generate sitemaps dynamically from your content source, not by crawling your own site — that way you cannot accidentally include orphaned or redirected URLs.
 
+**This site ships it.** `specification.website` generates [`/sitemap-index.xml`](/sitemap-index.xml) at build time from the content collection, and sets each `<lastmod>` from the entry's `updated` front matter — the same field the [RSS feed](/rss.xml) uses — rather than the build timestamp, so the date only moves when the content actually changes.
+
 ## Common mistakes
 
 - Listing non-canonical URLs (parameters, session IDs, alternate-case paths).


### PR DESCRIPTION
## What this changes

Implements dynamic sitemap generation that derives `<lastmod>` dates from the `updated` front matter field of spec entries, rather than using build timestamps. This ensures the sitemap stays in sync with actual content changes and matches the source of truth already used by the RSS feed.

**Code changes:**
- `astro.config.mjs`: Added `buildLastmodMap()` function that parses all spec entry front matter to extract `updated` dates and builds a canonical URL → lastmod map. Integrated into the sitemap serializer to populate `<lastmod>` for each URL.
- `src/content/spec/seo/xml-sitemaps.md`: Added a "This site ships it" section documenting that `specification.website` now generates sitemaps with accurate lastmod dates derived from content, not build time.

The implementation:
- Reads all `.md` and `.mdx` files under `src/content/spec/`
- Extracts `updated`, `category`, and `slug` from YAML front matter
- Skips draft entries
- Maps individual spec URLs and category index pages to their respective lastmod dates
- Sets root-level pages (`/`, `/spec/`, `/checklist/`) to the newest entry's date across the whole collection
- Passes the map to `@astrojs/sitemap`'s `serialize()` hook to inject ISO 8601 dates

## Sources

- [Sitemaps.org protocol](https://www.sitemaps.org/protocol.html) — `<lastmod>` specification
- [W3C: Last-Modified](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.29) — HTTP semantics

## Checklist

- [x] Sources cited on changed page.
- [x] Status is honest (page documents existing implementation).
- [x] Platform-agnostic — describes the outcome (accurate lastmod dates), not implementation details.
- [x] `npm run build` passes locally.
- [x] No accidental dependencies added (uses only Node.js built-ins and existing Astro integration).

https://claude.ai/code/session_016DgaQscUXMFQBcJX9Q1J63