### PR TITLE
Fix: update three broken Equalize Digital source URLs

### DIFF
--- a/src/content/spec/accessibility/color-contrast.md
+++ b/src/content/spec/accessibility/color-contrast.md
@@ -19,7 +19,7 @@ sources:
     url: "https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast.html"
     publisher: "W3C"
   - title: "Accessibility Checker — Low Contrast"
-    url: "https://equalizedigital.com/accessibility-checker/documentation/low-contrast/"
+    url: "https://equalizedigital.com/accessibility-checker/insufficient-color-contrast/"
     publisher: "Equalize Digital"
 ---
 

--- a/src/content/spec/accessibility/form-labels.md
+++ b/src/content/spec/accessibility/form-labels.md
@@ -16,7 +16,7 @@ sources:
     url: "https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html"
     publisher: "W3C"
   - title: "Accessibility Checker — Missing Form Label"
-    url: "https://equalizedigital.com/accessibility-checker/documentation/missing-form-label/"
+    url: "https://equalizedigital.com/accessibility-checker/empty-missing-form-label/"
     publisher: "Equalize Digital"
   - title: "WP Accessibility — Web Forms"
     url: "https://wpaccessibility.org/"

--- a/src/content/spec/accessibility/image-alt-text.md
+++ b/src/content/spec/accessibility/image-alt-text.md
@@ -13,7 +13,7 @@ sources:
     url: "https://www.w3.org/WAI/WCAG22/Understanding/non-text-content.html"
     publisher: "W3C"
   - title: "Accessibility Checker — Image Missing Alternative Text"
-    url: "https://equalizedigital.com/accessibility-checker/documentation/image-missing-alternative-text/"
+    url: "https://equalizedigital.com/accessibility-checker/missing-alternative-text/"
     publisher: "Equalize Digital"
   - title: "W3C WAI — Alt Decision Tree"
     url: "https://www.w3.org/WAI/tutorials/images/decision-tree/"


### PR DESCRIPTION
Three /accessibility-checker/documentation/* paths returned 404 — the pages moved to shorter slugs under /accessibility-checker/*.

## What this changes
Updates three broken Equalize Digital source URLs in the accessibility spec pages (colour-contrast, image-alt-text, form-labels). No content changes.

## Sources
  - Equalize Digital — Insufficient Color Contrast (https://equalizedigital.com/accessibility-checker/insufficient-color-contrast/)
  - Equalize Digital — Missing Alternative Text (https://equalizedigital.com/accessibility-checker/missing-alternative-text/)
  - Equalize Digital — Empty or Missing Form Label (https://equalizedigital.com/accessibility-checker/empty-missing-form-label/)

## Checklist

  - [x] Sources cited on every changed page.
  - [x] Status is honest (required, recommended, optional, avoid).
  - [x] Platform-agnostic — outcomes, not implementations.
  - [ ] npm run build passes locally.
  - [x] No accidental dependencies added.
