### PR TITLE
fix: broken links

### DIFF
--- a/src/content/spec/i18n/international-url-structure.md
+++ b/src/content/spec/i18n/international-url-structure.md
@@ -58,7 +58,7 @@ Then:
 
 - **Pair every canonical URL with [hreflang](/i18n/hreflang).** The URL pattern identifies the resource; hreflang tells search engines which locale it serves.
 - **Localise the slug where it adds clarity.** `/about/` to `/sobre/` is helpful for Spanish readers; `/api/v1/` is not worth translating. Consistency matters more than translation: localise all slugs in a section, or none.
-- **Keep slug rules from the general [URL structure](/seo/url-structure) page.** Lowercase, hyphenated, ASCII-where-possible, stable.
+- **Keep slug rules from the general [URL structure](/spec/seo/url-structure) page.** Lowercase, hyphenated, ASCII-where-possible, stable.
 - **Set the locale from the URL, not from the `Accept-Language` header.** The W3C recommends against silent language negotiation because it breaks sharing — see [avoid auto geo redirects](/i18n/avoid-auto-geo-redirects).
 
 ## Common mistakes

--- a/src/content/spec/security/caa-records.md
+++ b/src/content/spec/security/caa-records.md
@@ -63,7 +63,7 @@ example.com.    300    IN    CAA    0 issue "sectigo.com"
 
 Some CAs support extra parameters that pin the policy to a specific account or validation method. Let's Encrypt documents the `accounturi` and `validationmethods` extensions, which let you lock issuance to a specific ACME account.
 
-Pair CAA with [DNSSEC](/security/dnssec/) where possible. CAA without DNSSEC still helps — CAs check it — but DNSSEC stops an attacker from spoofing the DNS response.
+Pair CAA with [DNSSEC](/spec/security/dnssec/) where possible. CAA without DNSSEC still helps — CAs check it — but DNSSEC stops an attacker from spoofing the DNS response.
 
 ## Common mistakes
 

--- a/src/content/spec/security/content-security-policy.md
+++ b/src/content/spec/security/content-security-policy.md
@@ -56,7 +56,7 @@ Key directives:
 - **`script-src`** — controls JavaScript. Use a per-response nonce; the `strict-dynamic` keyword lets a trusted script load further trusted scripts.
 - **`style-src`** — controls CSS. Same nonce model where possible.
 - **`img-src`, `font-src`, `connect-src`, `media-src`** — list the third parties you actually use.
-- **`frame-ancestors 'none'`** — replaces `X-Frame-Options`. See [Clickjacking protection](/security/frame-ancestors/).
+- **`frame-ancestors 'none'`** — replaces `X-Frame-Options`. See [Clickjacking protection](/spec/security/frame-ancestors/).
 - **`object-src 'none'`** — kills Flash and plugin embeds.
 - **`base-uri 'none'`** — blocks `<base>` tag injection attacks.
 - **`report-to`** — endpoint that receives violation reports as JSON.

--- a/src/content/spec/security/dnssec.md
+++ b/src/content/spec/security/dnssec.md
@@ -59,7 +59,7 @@ Operational hygiene:
 - Automate key rollovers (KSK and ZSK). Manual rollovers fail.
 - Monitor signature expiry. An expired `RRSIG` is an outage.
 - Re-publish `DS` whenever the KSK rotates.
-- Pair with [CAA records](/security/caa-records/) for defence in depth around certificate issuance.
+- Pair with [CAA records](/spec/security/caa-records/) for defence in depth around certificate issuance.
 
 ## Common mistakes
 

--- a/src/content/spec/security/frame-ancestors.md
+++ b/src/content/spec/security/frame-ancestors.md
@@ -72,7 +72,7 @@ Content-Security-Policy: frame-ancestors 'self' https://partner.example.com
 
 Send the headers on every HTML response. Send them even on pages that "wouldn't make sense" framed; attackers will frame anything that performs an authenticated action.
 
-Combine with `SameSite` cookies (see [Cookie attributes](/security/cookie-attributes/)) for defence in depth.
+Combine with `SameSite` cookies (see [Cookie attributes](/spec/security/cookie-attributes/)) for defence in depth.
 
 ## Common mistakes
 

--- a/src/content/spec/security/https-tls.md
+++ b/src/content/spec/security/https-tls.md
@@ -48,7 +48,7 @@ HTTP/1.1 301 Moved Permanently
 Location: https://example.com/path
 ```
 
-Serve the same redirect on every hostname you own, including the apex, `www`, and any legacy subdomains. After HTTPS works, add [HSTS](/security/hsts/) so browsers stop trying HTTP at all.
+Serve the same redirect on every hostname you own, including the apex, `www`, and any legacy subdomains. After HTTPS works, add [HSTS](/spec/security/hsts/) so browsers stop trying HTTP at all.
 
 Cipher and protocol checklist:
 


### PR DESCRIPTION
## What this changes

As I was browsing the website, I noticed some links were broken. This adds the missing `spec/` root to some broken link paths.