### PR TITLE
fix(generate-assets): use fileURLToPath for cross-platform root path

### DIFF
--- a/scripts/generate-assets.mjs
+++ b/scripts/generate-assets.mjs
@@ -7,8 +7,9 @@
 import sharp from 'sharp';
 import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const root = new URL('..', import.meta.url).pathname;
+const root = fileURLToPath(new URL('..', import.meta.url));
 const out = join(root, 'public');
 const ogOut = join(out, 'og', 'spec');
 const contentRoot = join(root, 'src/content/spec');


### PR DESCRIPTION
## What this changes

Fixes the asset-generation script crashing on Windows.

`scripts/generate-assets.mjs` derived its repo root with:

```js
const root = new URL('..', import.meta.url).pathname;
```

On Windows, `.pathname` returns a leading-slash, percent-encoded URL path such as `/C:/Users/...`. Passing that to `path.join` produces a duplicated drive letter (`C:\C:\Users\...`), so `npm run dev` and `prebuild` fail with `ENOENT`. POSIX platforms happen to be unaffected, which is why CI and macOS/Linux dev never caught it.

The fix uses `fileURLToPath`, which returns a correct native path on every platform:

```js
import { fileURLToPath } from 'node:url';
const root = fileURLToPath(new URL('..', import.meta.url));
```

## Verification

- `node scripts/generate-assets.mjs` still runs clean on macOS — regenerates all icons, the default OG image, 10 category OG images, 131 per-page OG images, and 8 marketing OG images.
- No behaviour change on POSIX; corrects the path on Windows.

## Sources

- Node.js `url.fileURLToPath()` — the documented, cross-platform way to convert a `file:` URL to a path: <https://nodejs.org/api/url.html#urlfileurltopathurl-options>

Fixes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)