### PR TITLE
fix(security-txt): replace dead MDN citation; fix broken relatedSlug

### DIFF
--- a/src/content/spec/security/security-txt.md
+++ b/src/content/spec/security/security-txt.md
@@ -6,8 +6,8 @@ summary: "A standard text file at /.well-known/security.txt tells security resea
 status: recommended
 order: 40
 appliesTo: [all]
-relatedSlugs: [well-known-uris-overview, https-tls, hsts]
-updated: "2026-05-29T09:13:20.000Z"
+relatedSlugs: [well-known-overview, https-tls, hsts]
+updated: "2026-06-08T12:00:00.000Z"
 sources:
   - title: "RFC 9116 — A File Format to Aid in Security Vulnerability Disclosure"
     url: "https://www.rfc-editor.org/rfc/rfc9116"
@@ -15,9 +15,9 @@ sources:
   - title: "securitytxt.org"
     url: "https://securitytxt.org/"
     publisher: "securitytxt.org"
-  - title: "MDN — Well-known URIs"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Well-Known_URIs"
-    publisher: "MDN"
+  - title: "RFC 8615 — Well-Known Uniform Resource Identifiers (URIs)"
+    url: "https://www.rfc-editor.org/rfc/rfc8615"
+    publisher: "IETF"
 ---
 
 ## What it is


### PR DESCRIPTION
## What changed
Two small corrections on `security/security-txt.md`:

1. **Dead citation.** The third source, "MDN — Well-known URIs" (`https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Well-Known_URIs`), now returns **404** — MDN restructured its HTTP headers docs and removed that page. Replaced with the primary reference for the well-known mechanism, **RFC 8615**.
2. **Broken relatedSlug.** `relatedSlugs` listed `well-known-uris-overview`, which is not a real slug — the overview page's slug is `well-known-overview`. The cross-link was silently dead. Fixed.

`updated` bumped to 2026-06-08.

## Why now
Found during the daily rotating citation spot-check. Verified with `curl -I`: the old URL → 404; the RFC 8615 URL → 200.

## Verification
- `npm run build` passes (133 pages).
- Draft — for review, do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)