### PR TITLE
content: refresh stale MDN rel-attribute citations (reference reorg)

### DIFF
--- a/src/content/spec/foundations/canonical-url.md
+++ b/src/content/spec/foundations/canonical-url.md
@@ -7,13 +7,13 @@ status: recommended
 order: 70
 appliesTo: [all]
 relatedSlugs: [title, meta-description, open-graph, no-vary-search]
-updated: "2026-05-29T12:14:17.000Z"
+updated: "2026-06-18T00:00:00.000Z"
 sources:
   - title: "RFC 6596 — The Canonical Link Relation"
     url: "https://www.rfc-editor.org/rfc/rfc6596"
     publisher: "IETF"
   - title: "MDN — rel=canonical"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/canonical"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel#canonical"
     publisher: "MDN"
   - title: "Google — Consolidate duplicate URLs with canonicals"
     url: "https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls"

--- a/src/content/spec/foundations/feed-discovery.md
+++ b/src/content/spec/foundations/feed-discovery.md
@@ -7,13 +7,13 @@ status: recommended
 order: 110
 appliesTo: [all]
 relatedSlugs: [feed-hygiene, open-graph, canonical-url, machine-readable-formats, llms-txt, markdown-source-endpoints]
-updated: "2026-05-29T15:19:28.000Z"
+updated: "2026-06-18T00:00:00.000Z"
 sources:
   - title: "HTML Living Standard — Link types: alternate"
     url: "https://html.spec.whatwg.org/multipage/links.html#link-type-alternate"
     publisher: "WHATWG"
   - title: "MDN — rel=alternate"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/alternate"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel#alternate"
     publisher: "MDN"
   - title: "RSS 2.0 Specification"
     url: "https://www.rssboard.org/rss-specification"

--- a/src/content/spec/performance/preload-prefetch-preconnect.md
+++ b/src/content/spec/performance/preload-prefetch-preconnect.md
@@ -7,7 +7,7 @@ status: recommended
 order: 40
 appliesTo: [all]
 relatedSlugs: [resource-hints, core-web-vitals, font-loading]
-updated: "2026-05-29T20:27:54.000Z"
+updated: "2026-06-18T00:00:00.000Z"
 sources:
   - title: "MDN — <link>: The External Resource Link element"
     url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link"
@@ -19,7 +19,7 @@ sources:
     url: "https://web.dev/articles/preconnect-and-dns-prefetch"
     publisher: "web.dev"
   - title: "MDN — rel=preload"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/preload"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/preload"
     publisher: "MDN"
 ---
 

--- a/src/content/spec/performance/resource-hints.md
+++ b/src/content/spec/performance/resource-hints.md
@@ -7,7 +7,7 @@ status: recommended
 order: 100
 appliesTo: [all]
 relatedSlugs: [preload-prefetch-preconnect, font-loading, critical-css]
-updated: "2026-05-29T09:13:20.000Z"
+updated: "2026-06-18T00:00:00.000Z"
 sources:
   - title: "W3C — Resource Hints"
     url: "https://www.w3.org/TR/resource-hints/"
@@ -19,7 +19,7 @@ sources:
     url: "https://web.dev/articles/preload-critical-assets"
     publisher: "web.dev"
   - title: "MDN — rel=modulepreload"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/modulepreload"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/modulepreload"
     publisher: "MDN"
 ---
 


### PR DESCRIPTION
## What

MDN reorganised its HTML `rel` attribute documentation under `/Web/HTML/Reference/`. Four spec pages still cited the old deep links. Two of them now **404 outright**; the other two redirect but are stale. Repointed all four to their current canonical URLs and bumped `updated`.

| Page | Old (broken/stale) | New canonical |
|------|--------------------|---------------|
| [canonical-url](https://specification.website/spec/foundations/canonical-url/) | `…/Web/HTML/Attributes/rel/canonical` — **404** | `…/Web/HTML/Reference/Attributes/rel#canonical` |
| [feed-discovery](https://specification.website/spec/foundations/feed-discovery/) | `…/Web/HTML/Attributes/rel/alternate` — **404** | `…/Web/HTML/Reference/Attributes/rel#alternate` |
| [preload-prefetch-preconnect](https://specification.website/spec/performance/preload-prefetch-preconnect/) | `…/Web/HTML/Attributes/rel/preload` — stale redirect | `…/Web/HTML/Reference/Attributes/rel/preload` |
| [resource-hints](https://specification.website/spec/performance/resource-hints/) | `…/Web/HTML/Attributes/rel/modulepreload` — stale redirect | `…/Web/HTML/Reference/Attributes/rel/modulepreload` |

MDN now documents `canonical` and `alternate` as **anchors** on the consolidated `rel` reference page (verified 200, last modified 2026-04-20), while `preload` and `modulepreload` retain their own subpages under `/Reference/`.

## Why now

Daily standards-scan rotating citation check. Both `rel/canonical` and `rel/alternate` were confirmed `404 Not Found`; the MDN cardinal-rule says resolve to the current canonical URL rather than a rotted deep link.

## Notes

- Frontmatter-only change (source URL + `updated`); no body edits, no status change, no new page.
- **No changelog entry** — source-URL fixes are explicitly excluded by repo policy.

## Verification

`astro build` → 159 pages, Complete, no errors.

Draft — for maintainer review, not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)