### PR TITLE
fix(ci): harden links job against linkinator exit-13 crash

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -45,8 +45,28 @@ jobs:
             sleep 1
           done
           [ -n "$up" ] || { echo "::error::preview server did not start"; exit 1; }
-          npx --yes linkinator@6 http://localhost:4321 \
-            --recurse --skip "^https?://(?!localhost)"
+          # linkinator@6's CLI runs `await main()` at the top level; on newer Node
+          # the event loop can empty while that await is still pending, aborting the
+          # crawl with exit 13 ("unsettled top-level await") after fetching only /.
+          # That's a tooling crash, not a broken link — real breakage exits 1. Pin
+          # the exact version so an upstream 6.x patch can't shift the behaviour, and
+          # retry *only* on the exit-13 crash, never on a genuine finding. See #58.
+          attempt=1
+          max=3
+          while :; do
+            set +e
+            npx --yes linkinator@6.3.0 http://localhost:4321 \
+              --recurse --skip "^https?://(?!localhost)"
+            code=$?
+            set -e
+            [ "$code" -eq 0 ] && break
+            if [ "$code" -eq 13 ] && [ "$attempt" -lt "$max" ]; then
+              echo "::warning::linkinator crashed with exit 13 (unsettled top-level await); retrying ($attempt/$max)"
+              attempt=$((attempt + 1))
+              continue
+            fi
+            exit "$code"
+          done
 
   # Blocking: runs daily and on demand. A failed run signals rotted external
   # links that need fixing. Kept off PRs so a flaky upstream (IETF / W3C / MDN
@@ -100,5 +120,21 @@ jobs:
             sleep 1
           done
           [ -n "$up" ] || { echo "::error::preview server did not start"; exit 1; }
-          npx --yes linkinator@6 http://localhost:4321 \
-            --config linkinator.config.json
+          # Same exit-13 foot-gun as the internal job (see #58): pin the exact
+          # version and retry only on the top-level-await crash, not on real rot.
+          attempt=1
+          max=3
+          while :; do
+            set +e
+            npx --yes linkinator@6.3.0 http://localhost:4321 \
+              --config linkinator.config.json
+            code=$?
+            set -e
+            [ "$code" -eq 0 ] && break
+            if [ "$code" -eq 13 ] && [ "$attempt" -lt "$max" ]; then
+              echo "::warning::linkinator crashed with exit 13 (unsettled top-level await); retrying ($attempt/$max)"
+              attempt=$((attempt + 1))
+              continue
+            fi
+            exit "$code"
+          done


### PR DESCRIPTION
Fixes #58.

## Problem

The **Internal links** check flakes with exit code 13 ("unsettled top-level await"). linkinator@6's CLI runs `await main()` at the top level; on newer Node the event loop can empty while that await is still pending, aborting the crawl right after fetching `/` — before it recurses into any other page. The result is a false-red run that blocks PR merges (seen on #56), even though the content scans clean.

Both local and CI currently resolve `linkinator@6` to the same **6.3.0**, so this is a genuine timing race, not a version-specific bug — pinning alone wouldn't stop the current flake.

## Fix

Two layers, applied to both jobs in `links.yml`:

1. **Pin the exact version** (`linkinator@6.3.0`) so an upstream 6.x patch can't silently shift the behaviour underneath us.
2. **Retry only on the exit-13 crash** (up to 3 attempts). The crash is cleanly distinguishable from a real finding: linkinator exits **1** for genuine broken links, so those still fail the job *immediately* with no retry — no risk of masking real rot.

Verified the loop logic locally: an exit-13-then-0 sequence recovers and passes; an exit-1 broken-link finding fails on the first attempt without retrying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)