### PR TITLE
docs(a11y): native single-open accordions via details name

### DIFF
--- a/src/content/changelog/2026-07-08-exclusive-accordion.md
+++ b/src/content/changelog/2026-07-08-exclusive-accordion.md
@@ -1,0 +1,8 @@
+---
+title: Native single-open accordions with the details name attribute
+date: "2026-07-08"
+type: changed
+relatedSlugs: [native-interactive-elements]
+---
+
+Expanded [native interactive elements](/spec/accessibility/native-interactive-elements/) to cover grouping `<details>` elements by a shared `name`: the browser then enforces a single-open accordion natively — no JavaScript, and each panel keeps its keyboard, focus, and disclosure semantics. The behaviour is now interoperable across every engine (Firefox shipped it in 130).

--- a/src/content/spec/accessibility/native-interactive-elements.md
+++ b/src/content/spec/accessibility/native-interactive-elements.md
@@ -7,7 +7,7 @@ status: recommended
 order: 155
 appliesTo: [all]
 relatedSlugs: [semantic-html, aria-usage, keyboard-navigation, hidden-until-found, inert-attribute, invoker-commands]
-updated: "2026-05-29T16:40:22.000Z"
+updated: "2026-07-08T00:00:00.000Z"
 sources:
   - title: "WHATWG HTML — The details element"
     url: "https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element"
@@ -62,6 +62,21 @@ details::details-content {
 details[open]::details-content { block-size: auto; }
 ```
 
+**Single-open accordion** — give a group of sibling `<details>` the same `name` and the browser enforces that only one is open at a time, closing the others as each opens. No JavaScript, and every panel keeps its native keyboard activation, focus order, and disclosure semantics:
+
+```html
+<details name="faq">
+  <summary>How do refunds work?</summary>
+  <p>Refunds are issued to the original payment method within five days.</p>
+</details>
+<details name="faq">
+  <summary>Can I change my plan later?</summary>
+  <p>Yes — upgrade or downgrade at any time from your account settings.</p>
+</details>
+```
+
+A shared `name` turns a stack of disclosures into an exclusive accordion — the most common accordion pattern — without the `role`, `aria-expanded`, and roving-focus bookkeeping a scripted version has to reimplement and keep correct.
+
 **Modal dialog** — `<dialog>` with `showModal()`:
 
 ```html
@@ -89,6 +104,7 @@ details[open]::details-content { block-size: auto; }
 - **`<div onclick>` as a button.** No keyboard activation, no focus, no accessible name, no role.
 - **`<a href="#" onclick>` as a button.** Pollutes browser history, breaks middle-click and "open in new tab", and announces as a link in screen readers.
 - **Rebuilding `<details>` in JavaScript "to control the animation".** Modern CSS — `interpolate-size`, `transition-behavior: allow-discrete`, `::details-content` — animates the native element.
+- **Scripting a single-open accordion.** Give sibling `<details>` the same `name` and the browser handles mutual exclusion for you, with correct disclosure semantics on every panel.
 - **Using `<dialog>` for transient, non-blocking UI.** Reserve `<dialog>` for modal flows that require a decision. For menus, popovers, and toasts, use the [Popover API](/spec/foundations/popover-api/).
 - **Forgetting `type="button"` inside a `<form>`.** A bare `<button>` defaults to `type="submit"` and submits the form on click.
 


### PR DESCRIPTION
## What changed

Extends the **Native interactive elements** accessibility page to cover grouping `<details>` elements by a shared `name` attribute — the native single-open (exclusive) accordion pattern. Adds a worked `How to implement` subsection, a `Common mistakes` bullet, and bumps `updated`.

## Why now

- The `name`-grouping behaviour is **interoperable across every engine**, verified via MDN BCD (`html.elements.details.name`): Chrome/Edge 120 and Safari 17.2 (Dec 2023), **Firefox 130 (Sep 2024)**. Standard-track, non-experimental.
- The page already frames `<details>`/`<summary>` as the native disclosure primitive and shows `::details-content` animation, but never mentions that a shared `name` gives you a JS-free single-open accordion — the most common accordion requirement.

## Auditable outcome, not a build technique

Passes the outcome-not-technique bar (the one tightened on 2026-07-06). The "Why it matters" is phrasable for **visitors**, not the developer: a native single-open accordion gets keyboard activation, correct focus order, `aria-expanded`/disclosure semantics, open-state that survives back/forward navigation and in-page find, and graceful degradation with JS disabled — none of which a `div`+class-toggle accordion provides.

## Primary source

- WHATWG HTML — the `details` element / `attr-details-name` (already cited on the page).

## Status / changelog

- No status change; this is a `changed` enrichment of an existing `recommended` page.
- Includes a `changed` changelog entry (`2026-07-08-exclusive-accordion.md`). **This changelog call is borderline** per CLAUDE.md — if you'd rather not surface a single-subsection addition in `/changelog/`, drop that one file before merge.

## Notes for the reviewer

- Opened as **draft** by the automated daily standards scan.
- `eslint` + `prettier --check` passed via the pre-commit hook. `npm run build` could **not** be run in the sandboxed routine environment (npm is blocked there) — **CI is the build gate**; please confirm the build is green before merging.
- No new page, so no OG image or SKILL.md page-count change is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
