### PR TITLE
fix(security): SRI source is a Working Draft, not a Recommendation

### DIFF
--- a/src/content/spec/security/subresource-integrity.md
+++ b/src/content/spec/security/subresource-integrity.md
@@ -9,7 +9,7 @@ appliesTo: [all]
 relatedSlugs: [content-security-policy, https-tls, x-content-type-options, trusted-types, reporting-endpoints]
 updated: "2026-07-02T00:00:00.000Z"
 sources:
-  - title: "Subresource Integrity (W3C Recommendation)"
+  - title: "Subresource Integrity (W3C Working Draft)"
     url: "https://www.w3.org/TR/SRI/"
     publisher: "W3C"
   - title: "Subresource Integrity — §3.8 Integrity-Policy (W3C Editor's Draft)"


### PR DESCRIPTION
## What changed

Corrects one stale citation label on the **Subresource Integrity** page. The source titled *"Subresource Integrity (W3C Recommendation)"* → *"Subresource Integrity (W3C Working Draft)"*. URL unchanged.

## Why

`https://www.w3.org/TR/SRI/` now serves **"Subresource Integrity, W3C Working Draft, 20 March 2026"** (its "Latest published version" points to `/TR/sri-2/`, SRI Level 2), not a Recommendation. Verified directly this run. The old label misstated the document's standing.

Citing the current Working Draft is appropriate here — the page leans on `Integrity-Policy`, which is a Level 2 addition — so only the label needed correcting, not the URL.

## Scope

- Citation-label fix only; no body or status change. Per CLAUDE.md this is **not** a changelog-worthy change (source updates are excluded), so no changelog entry.
- Found by the daily standards scan's rotating citation spot-check. The rest of today's slice (10 pages across security/seo/perf/foundations/agent-readiness/a11y/i18n/privacy) was healthy; two external hosts on `https-tls.md` (`ssl-config.mozilla.org`, `ssllabs.com/ssltest`) could not be reached from the sandbox and should be re-checked on an unrestricted run before assuming any change.

## Notes for the reviewer

- Opened as **draft** by the automated daily standards scan.
- `eslint` + `prettier --check` passed via the pre-commit hook; `npm run build` is blocked in the sandboxed routine environment, so **CI is the build gate**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
