### PR TITLE
fix(well-known): drop mislabeled MDN citation on well-known-overview

### DIFF
--- a/src/content/spec/well-known/well-known-overview.md
+++ b/src/content/spec/well-known/well-known-overview.md
@@ -7,7 +7,7 @@ status: recommended
 order: 10
 appliesTo: [all]
 relatedSlugs: [change-password, openid-configuration, oauth-authorization-server, oauth-protected-resource, webfinger, apple-app-site-association, assetlinks-json, nodeinfo, api-catalog, webauthn]
-updated: "2026-06-08T12:00:00.000Z"
+updated: "2026-07-09T12:00:00.000Z"
 sources:
   - title: "RFC 8615 — Well-Known Uniform Resource Identifiers (URIs)"
     url: "https://www.rfc-editor.org/rfc/rfc8615"
@@ -15,9 +15,6 @@ sources:
   - title: "IANA — Well-Known URIs Registry"
     url: "https://www.iana.org/assignments/well-known-uris/well-known-uris.xhtml"
     publisher: "IANA"
-  - title: "MDN — Well-known URIs"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers"
-    publisher: "MDN"
 ---
 
 ## What it is


### PR DESCRIPTION
## What changed

Removed the third source on `src/content/spec/well-known/well-known-overview.md`, titled **"MDN — Well-known URIs"**, which pointed at `https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers` — the generic **HTTP Headers reference index**, unrelated to well-known URIs. Bumped `updated` to 2026-07-09.

## Why now

Daily standards scan flagged it as a stale/mislabeled citation (routine point 3). The title claims the link is about well-known URIs; the URL is the Headers reference. MDN has **no dedicated well-known URIs page** — confirmed via the MDN MCP server (`mcp.mdn.mozilla.net`), whose search for "well-known URI" returns only URI/encoding docs, nothing on the `/.well-known/` prefix. So the entry was mislabeled at authoring time, not merely moved by an MDN reorg — there is no correct canonical URL to redirect it to.

## Sources retained

- **RFC 8615** — Well-Known Uniform Resource Identifiers (IETF) — the defining standard.
- **IANA — Well-Known URIs Registry** — the authoritative name registry.

Both are primary sources; two is within the schema's 2–4 range, so no replacement is needed.

## Status

Unchanged (`recommended`). No content, page-count, or category change → no OG regenerate, no SKILL.md digest change, no changelog entry (source-only fix, invisible on the rendered page). `npm run build` passes; pre-commit lint/format/skill-drift green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)