### PR TITLE
fix(citations): update five SEO MDN links to their canonical paths

### DIFF
--- a/src/content/spec/seo/breadcrumbs.md
+++ b/src/content/spec/seo/breadcrumbs.md
@@ -19,7 +19,7 @@ sources:
     url: "https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/"
     publisher: "W3C WAI"
   - title: "MDN — aria-current"
-    url: "https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current"
+    url: "https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-current"
     publisher: "MDN"
 ---
 

--- a/src/content/spec/seo/heading-hierarchy.md
+++ b/src/content/spec/seo/heading-hierarchy.md
@@ -19,7 +19,7 @@ sources:
     url: "https://www.w3.org/WAI/tutorials/page-structure/headings/"
     publisher: "W3C WAI"
   - title: "MDN — Heading elements"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements"
     publisher: "MDN"
 ---
 

--- a/src/content/spec/seo/meta-robots.md
+++ b/src/content/spec/seo/meta-robots.md
@@ -19,7 +19,7 @@ sources:
     url: "https://www.bing.com/webmasters/help/which-robots-metatags-does-bing-support-5198d240"
     publisher: "Bing"
   - title: "MDN — <meta name=\"robots\">"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/name"
     publisher: "MDN"
 ---
 

--- a/src/content/spec/seo/redirects.md
+++ b/src/content/spec/seo/redirects.md
@@ -16,7 +16,7 @@ sources:
     url: "https://developers.google.com/search/docs/crawling-indexing/301-redirects"
     publisher: "Google Search Central"
   - title: "MDN — Redirections in HTTP"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Redirections"
     publisher: "MDN"
 ---
 

--- a/src/content/spec/seo/soft-404.md
+++ b/src/content/spec/seo/soft-404.md
@@ -16,7 +16,7 @@ sources:
     url: "https://www.rfc-editor.org/rfc/rfc9110.html#name-404-not-found"
     publisher: "IETF"
   - title: "MDN — HTTP response status codes"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status"
     publisher: "MDN"
 ---
 


### PR DESCRIPTION
## What changed

Five MDN citations in the **seo** category updated to their current canonical URLs. No prose changes, no status changes, no page-count change.

| File | Old path | New path |
|---|---|---|
| `seo/soft-404` | `/Web/HTTP/Status` | `/Web/HTTP/Reference/Status` |
| `seo/heading-hierarchy` | `/Web/HTML/Element/Heading_Elements` | `/Web/HTML/Reference/Elements/Heading_Elements` |
| `seo/redirects` | `/Web/HTTP/Redirections` | `/Web/HTTP/Guides/Redirections` |
| `seo/breadcrumbs` | `/Web/Accessibility/ARIA/Attributes/aria-current` | `/Web/Accessibility/ARIA/Reference/Attributes/aria-current` |
| `seo/meta-robots` | `/Web/HTML/Element/meta/name` | `/Web/HTML/Reference/Elements/meta/name` |

## Why now

This run's rotating citation-health slice was the **seo** category — the counterpart to yesterday's #93, which covered i18n + resilience + privacy. These five are the MDN reference-tree drift in seo. The old URLs still resolve via 301, so nothing is broken today, but CONTRIBUTING.md is explicit that hard-coded MDN deep links rot and should be resolved through the MDN MCP server.

**Every replacement above was resolved through the MDN MCP server**, not guessed by hand or pattern-matched from the old path.

## Checked and left alone (already canonical)

- `seo/internal-linking` → `/Learn_web_development/Core/Structuring_content/Creating_links` — current, no change.
- `seo/server-side-rendering` → `/Glossary/Progressive_Enhancement` — current (matches #93's finding), no change.

## Verification

- `npm run build` passes; 160 pages indexed.
- `npm run lint` + `npm run format:check` pass (pre-commit gate green, SKILL.md digest unchanged).

## Changelog

No entry. Per CLAUDE.md, citation-URL maintenance with no change to what a page *says* is not changelog material — same stance as #93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)