### PR TITLE
fix(citations): MDN HTML-element links → Reference/Elements canonical paths

### DIFF
--- a/src/content/spec/accessibility/captions-and-transcripts.md
+++ b/src/content/spec/accessibility/captions-and-transcripts.md
@@ -19,7 +19,7 @@ sources:
     url: "https://www.w3.org/WAI/WCAG22/Understanding/audio-only-and-video-only-prerecorded.html"
     publisher: "W3C"
   - title: "MDN — <track>: The Embed Text Track element"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/track"
     publisher: "MDN"
   - title: "WP Accessibility — Accessible media"
     url: "https://wpaccessibility.org/"

--- a/src/content/spec/accessibility/data-tables.md
+++ b/src/content/spec/accessibility/data-tables.md
@@ -16,7 +16,7 @@ sources:
     url: "https://html.spec.whatwg.org/multipage/tables.html"
     publisher: "WHATWG"
   - title: "MDN — <table>: The Table element"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/table"
     publisher: "MDN"
   - title: "Web Accessibility Tutorials — Tables"
     url: "https://www.w3.org/WAI/tutorials/tables/"

--- a/src/content/spec/accessibility/mobile-form-inputs.md
+++ b/src/content/spec/accessibility/mobile-form-inputs.md
@@ -16,7 +16,7 @@ sources:
     url: "https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-enterkeyhint-attribute"
     publisher: "WHATWG"
   - title: "MDN — <input>: types"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#input_types"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input#input_types"
     publisher: "MDN"
   - title: "MDN — text-size-adjust"
     url: "https://developer.mozilla.org/en-US/docs/Web/CSS/text-size-adjust"

--- a/src/content/spec/accessibility/native-interactive-elements.md
+++ b/src/content/spec/accessibility/native-interactive-elements.md
@@ -25,7 +25,7 @@ sources:
     url: "https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element"
     publisher: "WHATWG"
   - title: "MDN — <dialog>"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog"
     publisher: "MDN"
   - title: "WAI-ARIA Authoring Practices"
     url: "https://www.w3.org/WAI/ARIA/apg/"

--- a/src/content/spec/foundations/meta-charset.md
+++ b/src/content/spec/foundations/meta-charset.md
@@ -13,7 +13,7 @@ sources:
     url: "https://html.spec.whatwg.org/multipage/semantics.html#charset"
     publisher: "WHATWG"
   - title: "MDN — <meta>: charset"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#charset"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta#charset"
     publisher: "MDN"
   - title: "WHATWG Encoding Standard"
     url: "https://encoding.spec.whatwg.org/"

--- a/src/content/spec/foundations/meta-description.md
+++ b/src/content/spec/foundations/meta-description.md
@@ -10,7 +10,7 @@ relatedSlugs: [title, open-graph, canonical-url]
 updated: "2026-05-29T09:13:20.000Z"
 sources:
   - title: "MDN — <meta>: the metadata element"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta"
     publisher: "MDN"
   - title: "Google — Create good meta descriptions"
     url: "https://developers.google.com/search/docs/appearance/snippet"

--- a/src/content/spec/foundations/theme-color.md
+++ b/src/content/spec/foundations/theme-color.md
@@ -10,7 +10,7 @@ relatedSlugs: [color-scheme, favicons, meta-viewport, open-graph]
 updated: "2026-06-08T00:00:00.000Z"
 sources:
   - title: "MDN — <meta name=\"theme-color\">"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/name/theme-color"
     publisher: "MDN"
   - title: "HTML Living Standard — Other metadata names: theme-color"
     url: "https://html.spec.whatwg.org/multipage/semantics.html#meta-theme-color"

--- a/src/content/spec/foundations/title.md
+++ b/src/content/spec/foundations/title.md
@@ -13,7 +13,7 @@ sources:
     url: "https://html.spec.whatwg.org/multipage/semantics.html#the-title-element"
     publisher: "WHATWG"
   - title: "MDN — <title>: The Document Title element"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/title"
     publisher: "MDN"
   - title: "WCAG 2.4.2 — Page Titled (Level A)"
     url: "https://www.w3.org/WAI/WCAG22/Understanding/page-titled.html"

--- a/src/content/spec/performance/image-optimization.md
+++ b/src/content/spec/performance/image-optimization.md
@@ -10,7 +10,7 @@ relatedSlugs: [lazy-loading, core-web-vitals, preload-prefetch-preconnect]
 updated: "2026-05-29T09:13:20.000Z"
 sources:
   - title: "MDN — <img>: The Image Embed element"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img"
     publisher: "MDN"
   - title: "web.dev — Use modern image formats"
     url: "https://web.dev/articles/serve-images-webp"

--- a/src/content/spec/performance/lazy-loading.md
+++ b/src/content/spec/performance/lazy-loading.md
@@ -10,13 +10,13 @@ relatedSlugs: [image-optimization, core-web-vitals, preload-prefetch-preconnect]
 updated: "2026-05-29T09:51:43.000Z"
 sources:
   - title: "MDN — <img> loading attribute"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#loading"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#loading"
     publisher: "MDN"
   - title: "MDN — <iframe> loading attribute"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#loading"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe#loading"
     publisher: "MDN"
   - title: "MDN — <video> loading attribute"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#loading"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/video#loading"
     publisher: "MDN"
   - title: "HTML Living Standard — The video element"
     url: "https://html.spec.whatwg.org/multipage/media.html#the-video-element"
@@ -25,7 +25,7 @@ sources:
     url: "https://web.dev/articles/browser-level-image-lazy-loading"
     publisher: "web.dev"
   - title: "MDN — decoding attribute"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#decoding"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#decoding"
     publisher: "MDN"
 ---
 

--- a/src/content/spec/performance/preload-prefetch-preconnect.md
+++ b/src/content/spec/performance/preload-prefetch-preconnect.md
@@ -10,7 +10,7 @@ relatedSlugs: [resource-hints, early-hints, core-web-vitals, font-loading]
 updated: "2026-07-09T00:00:00.000Z"
 sources:
   - title: "MDN — <link>: The External Resource Link element"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link"
     publisher: "MDN"
   - title: "web.dev — Preload critical assets to improve loading speed"
     url: "https://web.dev/articles/preload-critical-assets"

--- a/src/content/spec/performance/resource-hints.md
+++ b/src/content/spec/performance/resource-hints.md
@@ -13,7 +13,7 @@ sources:
     url: "https://www.w3.org/TR/resource-hints/"
     publisher: "W3C"
   - title: "MDN — <link>: The External Resource Link element"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link"
     publisher: "MDN"
   - title: "web.dev — Preload critical assets"
     url: "https://web.dev/articles/preload-critical-assets"

--- a/src/content/spec/performance/script-loading.md
+++ b/src/content/spec/performance/script-loading.md
@@ -13,7 +13,7 @@ sources:
     url: "https://html.spec.whatwg.org/multipage/scripting.html#the-script-element"
     publisher: "WHATWG"
   - title: "MDN — <script>"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script"
     publisher: "MDN"
   - title: "Chrome for Developers — Eliminate render-blocking resources"
     url: "https://developer.chrome.com/docs/lighthouse/performance/render-blocking-resources"


### PR DESCRIPTION
## What changed

Updated **16 MDN citation URLs across 13 spec pages** from the old
`Web/HTML/Element/<el>` path to the current canonical
`Web/HTML/Reference/Elements/<el>` path.

Affected elements: `img`, `iframe`, `video`, `script`, `link`, `meta`, `title`,
`dialog`, `input`, `table`, `track`. Anchored fragments (`#loading`, `#decoding`,
`#charset`, `#input_types`) are preserved and verified to still resolve on the
new pages.

Files touched (frontmatter `sources` only, plus no body links):
foundations (meta-charset, title, theme-color, meta-description),
performance (script-loading, lazy-loading, resource-hints, image-optimization,
preload-prefetch-preconnect), accessibility (native-interactive-elements,
mobile-form-inputs, captions-and-transcripts, data-tables).

## Why now

MDN reorganised its HTML reference tree; the element pages moved under
`Web/HTML/Reference/Elements/`. The old URLs currently 301-redirect, so nothing
is visibly broken yet — but per the repo's citation policy (resolve MDN links to
their current canonical URL via the MDN MCP rather than relying on redirects that
rot), these should point at the real page. Each replacement was resolved through
the **MDN MCP server**, which returns the `Reference/Elements/<el>` path and
confirms the attribute anchors still exist on the new pages.

## Status / scope

- Citation-URL fix only — no spec text, status, or `relatedSlugs` changes.
- No changelog entry (link/citation maintenance, not a content change).
- No SKILL.md/page-count impact (162 pages, 10 categories unchanged).
- `npm run build`, `npm run lint`, `npm run format:check` all pass.

## Primary source

MDN Web Docs, current canonical element reference under
`https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/…`
(resolved per-element via the MDN MCP server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)