### PR TITLE
fix(citations): update eight MDN CSS links to their canonical Reference paths

### DIFF
--- a/src/content/spec/accessibility/mobile-form-inputs.md
+++ b/src/content/spec/accessibility/mobile-form-inputs.md
@@ -19,7 +19,7 @@ sources:
     url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input#input_types"
     publisher: "MDN"
   - title: "MDN — text-size-adjust"
-    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/text-size-adjust"
+    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/text-size-adjust"
     publisher: "MDN"
 ---
 

--- a/src/content/spec/foundations/meta-viewport.md
+++ b/src/content/spec/foundations/meta-viewport.md
@@ -16,7 +16,7 @@ sources:
     url: "https://drafts.csswg.org/css-device-adapt/#viewport-meta"
     publisher: "W3C"
   - title: "MDN — env() and the safe-area-inset-* variables"
-    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/env"
+    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/env"
     publisher: "MDN"
   - title: "WCAG 1.4.4 — Resize Text (Level AA)"
     url: "https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html"

--- a/src/content/spec/i18n/writing-modes.md
+++ b/src/content/spec/i18n/writing-modes.md
@@ -19,7 +19,7 @@ sources:
     url: "https://www.w3.org/International/articles/typography/linebreak.en"
     publisher: "W3C"
   - title: "MDN — writing-mode"
-    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/writing-mode"
+    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/writing-mode"
     publisher: "MDN"
 ---
 

--- a/src/content/spec/performance/css-containment.md
+++ b/src/content/spec/performance/css-containment.md
@@ -13,7 +13,7 @@ sources:
     url: "https://drafts.csswg.org/css-contain-2/"
     publisher: "W3C"
   - title: "MDN — contain"
-    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/contain"
+    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/contain"
     publisher: "MDN"
   - title: "web.dev — content-visibility: boost rendering performance"
     url: "https://web.dev/articles/content-visibility"

--- a/src/content/spec/performance/dynamic-viewport-units.md
+++ b/src/content/spec/performance/dynamic-viewport-units.md
@@ -13,7 +13,7 @@ sources:
     url: "https://drafts.csswg.org/css-values-4/#viewport-relative-lengths"
     publisher: "W3C CSSWG"
   - title: "MDN — Viewport-percentage lengths"
-    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/length#viewport-percentage_lengths"
+    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/length#viewport-percentage_lengths"
     publisher: "MDN"
   - title: "web.dev — The large, small, and dynamic viewport units"
     url: "https://web.dev/blog/viewport-units"

--- a/src/content/spec/performance/scroll-driven-animations.md
+++ b/src/content/spec/performance/scroll-driven-animations.md
@@ -16,7 +16,7 @@ sources:
     url: "https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_scroll-driven_animations"
     publisher: "MDN"
   - title: "MDN — animation-timeline"
-    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/animation-timeline"
+    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/animation-timeline"
     publisher: "MDN"
   - title: "Chrome for Developers — Scroll-driven animations"
     url: "https://developer.chrome.com/articles/scroll-driven-animations"

--- a/src/content/spec/performance/scrollbar-gutter.md
+++ b/src/content/spec/performance/scrollbar-gutter.md
@@ -13,7 +13,7 @@ sources:
     url: "https://drafts.csswg.org/css-overflow-3/#scrollbar-gutter-property"
     publisher: "W3C CSSWG"
   - title: "MDN — scrollbar-gutter"
-    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter"
+    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/scrollbar-gutter"
     publisher: "MDN"
   - title: "web.dev — scrollbar-gutter and scrollbar-width are Baseline Newly available"
     url: "https://web.dev/blog/baseline-scrollbar-props"

--- a/src/content/spec/performance/visibility-aware-rendering.md
+++ b/src/content/spec/performance/visibility-aware-rendering.md
@@ -13,7 +13,7 @@ sources:
     url: "https://drafts.csswg.org/css-contain-2/"
     publisher: "W3C CSSWG"
   - title: "MDN — content-visibility"
-    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/content-visibility"
+    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/content-visibility"
     publisher: "MDN"
   - title: "Intersection Observer"
     url: "https://www.w3.org/TR/intersection-observer/"


### PR DESCRIPTION
## What changed

Eight spec-page `sources` citations pointed at MDN's old flat `Web/CSS/<name>` URLs. MDN has reorganised its CSS reference tree — properties now live under `Web/CSS/Reference/Properties/`, and functions/data types under `Web/CSS/Reference/Values/` — so those old paths now 301-redirect. Each canonical URL was resolved via the **MDN MCP server** and updated in place.

| Page | Old path | Canonical path |
| --- | --- | --- |
| `foundations/meta-viewport` | `Web/CSS/env` | `Web/CSS/Reference/Values/env` |
| `performance/visibility-aware-rendering` | `Web/CSS/content-visibility` | `Web/CSS/Reference/Properties/content-visibility` |
| `performance/css-containment` | `Web/CSS/contain` | `Web/CSS/Reference/Properties/contain` |
| `performance/scrollbar-gutter` | `Web/CSS/scrollbar-gutter` | `Web/CSS/Reference/Properties/scrollbar-gutter` |
| `performance/scroll-driven-animations` | `Web/CSS/animation-timeline` | `Web/CSS/Reference/Properties/animation-timeline` |
| `performance/dynamic-viewport-units` | `Web/CSS/length#viewport-percentage_lengths` | `Web/CSS/Reference/Values/length#viewport-percentage_lengths` |
| `i18n/writing-modes` | `Web/CSS/writing-mode` | `Web/CSS/Reference/Properties/writing-mode` |
| `accessibility/mobile-form-inputs` | `Web/CSS/text-size-adjust` | `Web/CSS/Reference/Properties/text-size-adjust` |

## Why now

Daily standards scan, rotating citation slice (i18n + privacy this run) surfaced `Web/CSS/writing-mode` as drifted; widening the check found the full flat-path cluster. This is the same MDN reference-tree reorg addressed for HTML elements and other paths in #93–#95 — MDN is a **context** source on each of these pages, so the primary standard citation is untouched.

## Status / scope

Citation-URL hygiene only — no content, status, or page-count change (per CLAUDE.md, citation fixes are not changelog-logged and need no SKILL.md/OG regeneration). `npm run build` passes (162 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)