### PR TITLE
fix(mcp): bump @cloudflare/workers-types to v5 (unblock Deploy MCP)

### DIFF
--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260702.1",
+        "@cloudflare/workers-types": "^5.20260708.1",
         "typescript": "^6.0.3",
         "wrangler": "^4.110.0",
         "yaml": "^2.6.0"
@@ -127,9 +127,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260702.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
-      "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
+      "version": "5.20260714.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260714.1.tgz",
+      "integrity": "sha512-HGCTQVIQwzqAMLrZBCgLDrWKMgOdi6yn+S0Do1rF6z7t8tVvNprQfa53V6EDRRwsVO92uN5gviX2SxASDINZfA==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260702.1",
+    "@cloudflare/workers-types": "^5.20260708.1",
     "typescript": "^6.0.3",
     "wrangler": "^4.110.0",
     "yaml": "^2.6.0"


### PR DESCRIPTION
## Problem

The Deploy MCP action failed on the wrangler `4.107→4.110` bump (#98): wrangler 4.110 declares a `peerOptional` on `@cloudflare/workers-types@^5`, but `/mcp/package.json` still pinned `^4.20260702.1`, so `npm ci` aborted with `ERESOLVE` and the Worker never redeployed.

PR CI for #98 passed because it builds the root Astro project, not `/mcp` under strict `npm ci`.

## Fix

Align `/mcp` on `@cloudflare/workers-types@^5.20260708.1` (the floor wrangler 4.110 asks for). The root project already runs workers-types v5, so v5 is proven compatible with this stack.

## Verified locally

- `npm ci` in `/mcp` — passes (the exact step that failed)
- `npm run build:data` — 162 pages, 10 categories
- `tsc --noEmit` — clean
- `wrangler deploy --dry-run` — bundles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)