### PR TITLE
ops(scan): add mnot.net/blog as a watch source for the daily standards scan

### DIFF
--- a/ops/routines/daily-standards-scan.md
+++ b/ops/routines/daily-standards-scan.md
@@ -40,6 +40,11 @@ cases and **(b)** send one Slack summary of everything found.
 - Adjacent (watch, don't blindly trust): `web.dev` — especially <https://web.dev/blog> —
   `developer.chrome.com`, Google Search Central — for emerging conventions worth
   promoting LATER
+- <https://mnot.net/blog/> (Mark Nottingham: HTTP WG co-chair and a designated expert for
+  the IANA HTTP Field Name registry): high-signal early commentary on HTTP headers,
+  Structured Fields, caching, and registry/protocol movement, often ahead of the RFC.
+  Treat what he flags as a lead to investigate; a page still cites the primary standard,
+  not the blog.
 
 ## Tools — use the MDN MCP server
 


### PR DESCRIPTION
Adds [Mark Nottingham's blog](https://mnot.net/blog/) to the daily standards scan's source list (`ops/routines/daily-standards-scan.md`).

Placed in the **"adjacent (watch, don't blindly trust)"** bucket, alongside web.dev / Chrome / Search Central: it's a personal blog, so it's a lead to investigate rather than a citable primary source. But it's an unusually high-signal one — Nottingham co-chairs the IETF HTTP WG and is a designated expert for the IANA HTTP Field Name registry, so his posts often surface HTTP header / Structured Fields / caching / registry changes ahead of the RFC.

Docs-only change to the routine's single source of truth; the next scheduled run picks it up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)