### PR TITLE
ops(scan): fix the always-empty webstatus.dev "widely" Baseline query

### DIFF
--- a/ops/routines/daily-standards-scan.md
+++ b/ops/routines/daily-standards-scan.md
@@ -32,11 +32,29 @@ cases and **(b)** send one Slack summary of everything found.
   movement): `https://api.webstatus.dev/v1/features?q=baseline_status:newly` (public, no
   auth, JSON) lists features that have _newly_ reached Baseline; add
   `baseline_date:<START>..<END>` to scope to this run's window — use a trailing ~8-day
-  window so a skipped run never drops a feature. `baseline_status:widely` catches the
-  newly-Baseline → Widely transition (a feature now safe to rely on everywhere). This is
-  the discovery step for section #2's Baseline check; the MDN MCP then corroborates each
-  hit and supplies the canonical primary-source URL. It is derived data, not editorial —
-  trustworthy as a signal, but a page still cites the primary standard, not webstatus.dev.
+  window so a skipped run never drops a feature. This is the discovery step for section
+  #2's Baseline check; the MDN MCP then corroborates each hit and supplies the canonical
+  primary-source URL. It is derived data, not editorial — trustworthy as a signal, but a
+  page still cites the primary standard, not webstatus.dev.
+
+  **`baseline_date` always matches a feature's _low_ date** (the day it went _newly_), even
+  when you filter on `baseline_status:widely`. Widely is reached ~30 months after newly, so
+  a feature that goes Widely today has a low date ~30 months in the past. This means the
+  intuitive query — `baseline_status:widely AND baseline_date:<this run's window>` — is
+  **always empty** and silently reports "no transitions" forever. To catch the newly →
+  Widely transition, offset the window back ~30 months:
+
+  ```
+  # Newly Baseline this run (trailing ~8-day window on the low date):
+  baseline_status:newly AND baseline_date:<TODAY-8>..<TODAY>
+
+  # Went WIDELY this run — same window shifted back 30 months:
+  baseline_status:widely AND baseline_date:<TODAY-30mo-8d>..<TODAY-30mo>
+  ```
+
+  Sanity-check the offset against the returned `baseline.high_date` rather than trusting
+  the 30-month rule of thumb; the API returns both `low_date` and `high_date` per feature.
+
 - Adjacent (watch, don't blindly trust): `web.dev` — especially <https://web.dev/blog> —
   `developer.chrome.com`, Google Search Central — for emerging conventions worth
   promoting LATER


### PR DESCRIPTION
## What changed

`ops/routines/daily-standards-scan.md` — documents that webstatus.dev's `baseline_date` filter keys off a feature's **low** date, and gives the corrected query shape for catching newly → Widely transitions.

## Why now

Today's scan run tripped over this. The routine currently says:

> `baseline_status:widely` catches the newly-Baseline → Widely transition (a feature now safe to rely on everywhere)

scoped by `baseline_date:<START>..<END>` with "a trailing ~8-day window". **That combination can never match anything.** `baseline_date` filters on the feature's *low* date (when it went *newly*), not its high date. Widely is reached ~30 months after newly, so a feature that goes Widely today has a low date ~30 months in the past.

The failure mode is the bad kind: no error, just `total: 0` every single run. Half the Baseline check has been reporting "nothing moved" unconditionally, and would have kept doing so indefinitely.

## Verification

Both queries run against the public API today (2026-07-17):

| Query | `metadata.total` |
| --- | --- |
| `baseline_status:widely AND baseline_date:2026-06-01..2026-07-17` (routine as written) | **0** |
| `baseline_status:widely AND baseline_date:2023-12-01..2024-01-31` (window offset back ~30mo) | **16** |

The second returns the features that actually went Widely in June 2026 — `has`, `loading-lazy`, `nesting`, `storage-access`, `masks`, `:dir()`, `url-canparse` and others. Every one has `high_date` = `low_date` + 30 months exactly, which is what confirms the filter keys off `low_date`.

Sample from that response:

| feature_id | low_date | high_date |
| --- | --- | --- |
| `has` | 2023-12-19 | 2026-06-19 |
| `loading-lazy` | 2023-12-19 | 2026-06-19 |
| `storage-access` | 2023-12-05 | 2026-06-05 |

## Source

- <https://api.webstatus.dev/v1/features> — public, no auth. Both queries above are reproducible as-is.

## Status justification

Not a spec-content change — this is routine plumbing, so **no changelog entry** per the CLAUDE.md rule that the changelog tracks what the spec *says*, not tooling.

Worth noting what this fix does **not** change: the 16 features it now surfaces were reviewed this run anyway, and 14 are rejected by the auditable-outcome rule (CSS/JS authoring ergonomics — the subgrid/#82 precedent). The other two (`loading-lazy`, `storage-access`) are already covered and their statuses stay correct. So the immediate yield is zero new pages; the value is that the query stops lying on future runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)