### PR TITLE
fix(security): RFC 8446 is obsolete — cite RFC 9846 for TLS 1.3

### DIFF
--- a/src/content/spec/security/https-tls.md
+++ b/src/content/spec/security/https-tls.md
@@ -7,10 +7,13 @@ status: required
 order: 10
 appliesTo: [all]
 relatedSlugs: [hsts, caa-records, content-security-policy, mixed-content]
-updated: "2026-07-09T00:00:00.000Z"
+updated: "2026-07-17T00:00:00.000Z"
 sources:
-  - title: "RFC 8446 — The Transport Layer Security (TLS) Protocol Version 1.3"
-    url: "https://www.rfc-editor.org/rfc/rfc8446"
+  - title: "RFC 9846 — The Transport Layer Security (TLS) Protocol Version 1.3"
+    url: "https://www.rfc-editor.org/rfc/rfc9846"
+    publisher: "IETF"
+  - title: "RFC 9851 — TLS 1.2 is in Feature Freeze"
+    url: "https://www.rfc-editor.org/rfc/rfc9851"
     publisher: "IETF"
   - title: "Mozilla SSL Configuration Generator"
     url: "https://ssl-config.mozilla.org/"
@@ -25,7 +28,9 @@ sources:
 
 ## What it is
 
-HTTPS is HTTP carried over TLS, a protocol that encrypts and authenticates the connection between the browser and the server. TLS 1.3 (RFC 8446) is the current version; TLS 1.2 remains acceptable. Everything earlier — TLS 1.0, TLS 1.1, and all versions of SSL — is broken and must be disabled.
+HTTPS is HTTP carried over TLS, a protocol that encrypts and authenticates the connection between the browser and the server. TLS 1.3 is the current version, specified by RFC 9846 — a July 2026 revision that obsoleted RFC 8446 without changing the version number or breaking compatibility. TLS 1.2 remains acceptable. Everything earlier — TLS 1.0, TLS 1.1, and all versions of SSL — is broken and must be disabled.
+
+"Acceptable" is not the same as "equal", though, and the gap is widening rather than holding steady. TLS 1.2 is in feature freeze (RFC 9851): it receives urgent security fixes and nothing else, and post-quantum key exchange is being specified for TLS 1.3 and later only. Keeping TLS 1.2 enabled for the clients that still need it is sound; treating it as a version you can sit on indefinitely is not.
 
 What HTTPS does not do is vouch for the site. The certificate proves you are talking to the genuine holder of the name in the address bar, and that nobody on the path can read or alter the bytes. It says nothing about whether that party is honest: a phishing page served over flawless HTTPS shows the same padlock a bank does. HTTPS secures the channel, not the character of whatever is at the far end of it.
 


### PR DESCRIPTION
## What changed

`src/content/spec/security/https-tls.md`:

1. **Lead source `RFC 8446` → `RFC 9846`.** The page cited an obsolete RFC as its primary standard.
2. **Body claim fixed.** "TLS 1.3 (RFC 8446) is the current version" was stale in the same way.
3. **Added RFC 9851 + one paragraph of nuance** on what "TLS 1.2 remains acceptable" does and doesn't mean.
4. `updated` bumped to 2026-07-17.

## Why now

**[RFC 9846 — The Transport Layer Security (TLS) Protocol Version 1.3](https://www.rfc-editor.org/rfc/rfc9846)** (July 2026, Standards Track, E. Rescorla) **obsoletes RFC 8446**, along with 5077, 5246, 6961, 7627 and 8422; it updates 5705 and 6066. It is self-described as "a minor update to TLS 1.3 that retains the same version number and is backward compatible."

This is precisely the dead/stale-citation class the daily scan exists to catch: the page's lead citation pointed at a superseded document, and the body stated it as current fact.

## The nuance pass, and why it earns its space

The page said TLS 1.2 "remains acceptable" and stopped there — leaving a reader to conclude it is *equivalent*. Two July 2026 RFCs say otherwise:

- **[RFC 9851 — TLS 1.2 is in Feature Freeze](https://www.rfc-editor.org/rfc/rfc9851)** (Standards Track): no changes to TLS 1.2 outside urgent security fixes; post-quantum cryptography is being specified for TLS 1.3 or later **only**.

So the honest framing is: keep TLS 1.2 on for the clients that need it, don't plan around it as a destination. That's a real explanation rather than padding — it names the wrong belief the reader arrives with (cardinal rule 7).

## What I deliberately did *not* do

**No status change. TLS 1.2 stays acceptable for websites, and the page stays `required`.**

[RFC 9852](https://www.rfc-editor.org/rfc/rfc9852) (BCP 195, July 2026) mandates TLS 1.3 for **new protocols** and [RFC 10015](https://www.rfc-editor.org/rfc/rfc10015) deprecates obsolete TLS 1.2 key exchange — but neither is a statement about how a website configures its server. Citing them as pressure on site operators would be an overreach, so they're mentioned here for the record and left off the page. The Mozilla Intermediate profile (TLS 1.2 + 1.3) remains the right default for public sites.

## Verification

- `npm run build` passes (163 pages indexed).
- `npm run format:check` clean; pre-commit skill-drift check passes.
- No page count or category change, so no SKILL.md/digest update needed.

## Changelog

**No entry** — this follows the precedent of #93/#94/#95/#101, which shipped citation fixes without one, and per CLAUDE.md the changelog tracks what the spec *says*, not source hygiene. That said, the TLS 1.2 feature-freeze paragraph is a small substantive addition rather than a pure link swap, so this is **borderline** — happy to add a `changed` entry if you'd rather surface it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)