### PR TITLE
fix(citations): repair 2 drifted MDN links in foundations

### DIFF
--- a/src/content/spec/foundations/doctype.md
+++ b/src/content/spec/foundations/doctype.md
@@ -7,7 +7,7 @@ status: required
 order: 10
 appliesTo: [all]
 relatedSlugs: [html-lang, meta-charset, meta-viewport]
-updated: "2026-07-09T00:00:00.000Z"
+updated: "2026-07-27T00:00:00.000Z"
 sources:
   - title: "HTML Living Standard — The DOCTYPE"
     url: "https://html.spec.whatwg.org/multipage/syntax.html#the-doctype"
@@ -16,7 +16,7 @@ sources:
     url: "https://developer.mozilla.org/en-US/docs/Glossary/Doctype"
     publisher: "MDN"
   - title: "MDN — Quirks Mode and Standards Mode"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Quirks_mode_and_standards_mode"
     publisher: "MDN"
 ---
 

--- a/src/content/spec/foundations/meta-viewport.md
+++ b/src/content/spec/foundations/meta-viewport.md
@@ -7,10 +7,10 @@ status: required
 order: 40
 appliesTo: [all]
 relatedSlugs: [doctype, meta-charset, theme-color, dynamic-viewport-units, mobile-form-inputs]
-updated: "2026-06-08T00:00:00.000Z"
+updated: "2026-07-27T00:00:00.000Z"
 sources:
   - title: "MDN — Viewport meta tag"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/name/viewport"
     publisher: "MDN"
   - title: "CSS Device Adaptation Module — viewport meta"
     url: "https://drafts.csswg.org/css-device-adapt/#viewport-meta"


### PR DESCRIPTION
## What changed

Two MDN reference citations in the **foundations** category had drifted — MDN reorganised its reference tree and the cited deep links now redirect. Resolved the current canonical URLs via the MDN MCP server and updated them in place.

| Page | Old (redirecting) | New (canonical) |
|------|-------------------|-----------------|
| [`doctype`](src/content/spec/foundations/doctype.md) | `Web/HTML/Quirks_Mode_and_Standards_Mode` | `Web/HTML/Guides/Quirks_mode_and_standards_mode` |
| [`meta-viewport`](src/content/spec/foundations/meta-viewport.md) | `Web/HTML/Viewport_meta_tag` | `Web/HTML/Reference/Elements/meta/name/viewport` |

## Why now

Surfaced by the daily standards scan's rotating citation spot-check (foundations slice, 2026-07-27). Both links still resolve via redirect today, but redirects rot — pinning the canonical target keeps the citation honest.

## Notes

- Frontmatter `sources` only; no body/content change, no status change. `updated` bumped on both pages.
- MDN stays a **context** source on both pages; each still leads with the primary standard (WHATWG HTML Living Standard / W3C CSS Device Adaptation).
- No changelog entry — per CLAUDE.md, citation-URL fixes are not logged. No page/category count change, so SKILL.md digest is unaffected (pre-commit confirms).
- `npm run build` passes; Prettier + ESLint + skill-drift pre-commit checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)