### PR TITLE
fix(citations): repair 7 drifted MDN links in accessibility

### DIFF
--- a/src/content/spec/accessibility/css-state-selectors.md
+++ b/src/content/spec/accessibility/css-state-selectors.md
@@ -7,16 +7,16 @@ status: recommended
 order: 160
 appliesTo: [all]
 relatedSlugs: [form-errors, form-labels, focus-indicators, semantic-html]
-updated: "2026-05-29T16:40:22.000Z"
+updated: "2026-07-28T00:00:00.000Z"
 sources:
   - title: "W3C Selectors Level 4 — Relational selector `:has()`"
     url: "https://www.w3.org/TR/selectors-4/#relational"
     publisher: "W3C"
   - title: "MDN — `:has()`"
-    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/:has"
+    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/:has"
     publisher: "MDN"
   - title: "MDN — `:user-invalid`"
-    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/:user-invalid"
+    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/:user-invalid"
     publisher: "MDN"
   - title: "HTML Living Standard — Constraint validation"
     url: "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constraint-validation"

--- a/src/content/spec/accessibility/focus-indicators.md
+++ b/src/content/spec/accessibility/focus-indicators.md
@@ -7,7 +7,7 @@ status: required
 order: 50
 appliesTo: [all]
 relatedSlugs: [keyboard-navigation, color-contrast, inert-attribute, focus-not-obscured]
-updated: "2026-07-17T00:00:00.000Z"
+updated: "2026-07-28T00:00:00.000Z"
 sources:
   - title: "WCAG 2.4.7 — Focus Visible (Level AA)"
     url: "https://www.w3.org/WAI/WCAG22/Understanding/focus-visible.html"
@@ -19,7 +19,7 @@ sources:
     url: "https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance.html"
     publisher: "W3C"
   - title: "MDN — :focus-visible"
-    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible"
+    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/:focus-visible"
     publisher: "MDN"
 ---
 

--- a/src/content/spec/accessibility/form-errors.md
+++ b/src/content/spec/accessibility/form-errors.md
@@ -7,7 +7,7 @@ status: required
 order: 110
 appliesTo: [all]
 relatedSlugs: [form-labels, aria-usage, color-contrast, mobile-form-inputs, accessible-authentication, redundant-entry]
-updated: "2026-05-29T09:13:20.000Z"
+updated: "2026-07-28T00:00:00.000Z"
 sources:
   - title: "WCAG 3.3.1 — Error Identification (Level A)"
     url: "https://www.w3.org/WAI/WCAG22/Understanding/error-identification.html"
@@ -19,7 +19,7 @@ sources:
     url: "https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html"
     publisher: "W3C"
   - title: "MDN — ARIA live regions"
-    url: "https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions"
+    url: "https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions"
     publisher: "MDN"
 ---
 

--- a/src/content/spec/accessibility/reduced-motion.md
+++ b/src/content/spec/accessibility/reduced-motion.md
@@ -7,7 +7,7 @@ status: required
 order: 125
 appliesTo: [all]
 relatedSlugs: [focus-indicators, semantic-html, color-contrast, forced-colors]
-updated: "2026-05-29T10:57:27.000Z"
+updated: "2026-07-28T00:00:00.000Z"
 sources:
   - title: "WCAG 2.3.3 — Animation from Interactions (Level AAA)"
     url: "https://www.w3.org/WAI/WCAG22/Understanding/animation-from-interactions.html"
@@ -16,7 +16,7 @@ sources:
     url: "https://www.w3.org/WAI/WCAG22/Understanding/pause-stop-hide.html"
     publisher: "W3C"
   - title: "MDN — prefers-reduced-motion"
-    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion"
+    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/prefers-reduced-motion"
     publisher: "MDN"
   - title: "WP Accessibility"
     url: "https://wpaccessibility.org/"

--- a/src/content/spec/accessibility/semantic-html.md
+++ b/src/content/spec/accessibility/semantic-html.md
@@ -7,13 +7,13 @@ status: required
 order: 70
 appliesTo: [all]
 relatedSlugs: [aria-usage, skip-links, keyboard-navigation]
-updated: "2026-05-29T10:57:27.000Z"
+updated: "2026-07-28T00:00:00.000Z"
 sources:
   - title: "WCAG 1.3.1 — Info and Relationships (Level A)"
     url: "https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html"
     publisher: "W3C"
   - title: "MDN — HTML elements reference"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Element"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements"
     publisher: "MDN"
   - title: "W3C WAI — ARIA Landmarks"
     url: "https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/"

--- a/src/content/spec/accessibility/touch-target-size.md
+++ b/src/content/spec/accessibility/touch-target-size.md
@@ -8,7 +8,7 @@ order: 145
 appliesTo: [all]
 relatedSlugs:
   [keyboard-navigation, focus-indicators, empty-links-buttons, mobile-form-inputs, dragging-movements]
-updated: "2026-06-08T00:00:00.000Z"
+updated: "2026-07-28T00:00:00.000Z"
 sources:
   - title: "WCAG 2.5.8 — Target Size (Minimum) Level AA"
     url: "https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html"
@@ -17,7 +17,7 @@ sources:
     url: "https://www.w3.org/WAI/WCAG22/Understanding/target-size-enhanced.html"
     publisher: "W3C"
   - title: "MDN — pointer (media feature)"
-    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/@media/pointer"
+    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/pointer"
     publisher: "MDN"
   - title: "Human Interface Guidelines — Layout"
     url: "https://developer.apple.com/design/human-interface-guidelines/layout"


### PR DESCRIPTION
## What changed

Seven MDN citations across six accessibility pages now point at their current canonical paths:

| Page | Old path | Canonical path |
| --- | --- | --- |
| `css-state-selectors` | `/Web/CSS/:has` | `/Web/CSS/Reference/Selectors/:has` |
| `css-state-selectors` | `/Web/CSS/:user-invalid` | `/Web/CSS/Reference/Selectors/:user-invalid` |
| `focus-indicators` | `/Web/CSS/:focus-visible` | `/Web/CSS/Reference/Selectors/:focus-visible` |
| `reduced-motion` | `/Web/CSS/@media/prefers-reduced-motion` | `/Web/CSS/Reference/At-rules/@media/prefers-reduced-motion` |
| `touch-target-size` | `/Web/CSS/@media/pointer` | `/Web/CSS/Reference/At-rules/@media/pointer` |
| `semantic-html` | `/Web/HTML/Element` | `/Web/HTML/Reference/Elements` |
| `form-errors` | `/Web/Accessibility/ARIA/ARIA_Live_Regions` | `/Web/Accessibility/ARIA/Guides/Live_regions` |

`updated` bumped to `2026-07-28` on all six pages.

## Why now

The daily standards scan rotated onto the `accessibility`, `privacy` and `well-known` slices. MDN has reorganised its reference tree — CSS selectors and at-rules now live under `Reference/`, the HTML element index moved to `HTML/Reference/Elements`, and the ARIA live-regions article moved into `ARIA/Guides/`. The old URLs still 301, so the `links.yml` job never flags them; they only surface as drift when resolved against MDN directly.

## Sources

Every replacement URL was resolved through the **MDN MCP server** (`https://mcp.mdn.mozilla.net/`), which returns the current canonical path — per the CONTRIBUTING rule for MDN citations.

Checked and left alone in the same slice (already canonical): `/Web/Accessibility/ARIA`, `/Web/HTTP/Guides/CSP`, `/Web/Security/Defenses/Subresource_Integrity`, `/Web/API/Storage_Access_API`, `/Web/API/Document/requestStorageAccess`, `/Web/HTML/Reference/Attributes/autocomplete`.

## Status

No status changes — these are citation repairs only. No changelog entry: per `CLAUDE.md` the changelog is for what the spec *says*, and nothing a reader sees on a page changed beyond the source link target.

`npm run build` passes; Prettier and the SKILL.md digest check pass via the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)