### PR TITLE
fix(accessibility): "Using ARIA" is a discontinued draft — cite the ARIA in HTML REC

### DIFF
--- a/src/content/spec/accessibility/aria-usage.md
+++ b/src/content/spec/accessibility/aria-usage.md
@@ -7,14 +7,14 @@ status: recommended
 order: 80
 appliesTo: [all]
 relatedSlugs: [semantic-html, form-labels, keyboard-navigation]
-updated: "2026-05-29T09:13:20.000Z"
+updated: "2026-07-31T00:00:00.000Z"
 sources:
+  - title: "ARIA in HTML (W3C Recommendation, 15 April 2026)"
+    url: "https://www.w3.org/TR/html-aria/"
+    publisher: "W3C"
   - title: "ARIA Authoring Practices Guide — Read Me First"
     url: "https://www.w3.org/WAI/ARIA/apg/practices/read-me-first/"
     publisher: "W3C WAI"
-  - title: "Using ARIA"
-    url: "https://www.w3.org/TR/using-aria/"
-    publisher: "W3C"
   - title: "MDN — ARIA"
     url: "https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA"
     publisher: "MDN"
@@ -29,17 +29,20 @@ ARIA — Accessible Rich Internet Applications — is a set of HTML attributes (
 
 ## Why it matters
 
-ARIA is a sharp tool. Used well, it lets you describe widgets the HTML spec does not cover. Used badly, it overrides the real semantics of an element and makes the page *less* accessible than the unstyled HTML would have been. The W3C's own guide leads with five rules — and the first is the most important.
+ARIA is a sharp tool. Used well, it lets you describe widgets the HTML spec does not cover. Used badly, it overrides the real semantics of an element and makes the page *less* accessible than the unstyled HTML would have been. The W3C's four rules of ARIA lead with the most important one: reach for native HTML first.
+
+Which roles and attributes are actually *allowed* on a given element is not a matter of taste either. [ARIA in HTML](https://www.w3.org/TR/html-aria/) became a W3C Recommendation in April 2026 and specifies it element by element. The answers are not always the intuitive ones: `role="button"` on an `<a href>` is permitted, while `<textarea>` accepts no role other than the `textbox` it already has, and `<input type="hidden">` accepts no `role` or `aria-*` attribute at all.
 
 ## How to implement
 
-The five rules of ARIA, in plain English:
+The four rules of ARIA, in plain English:
 
 1. **Don't use ARIA if a native HTML element will do.** `<button>`, `<a href>`, `<input type="checkbox">`, `<details>` — these come with role, focus, and keyboard support for free.
 2. **Don't change native semantics.** Never write `<h1 role="button">`. If you need a button, use a `<button>`.
 3. **All interactive ARIA controls must be keyboard-operable.** A `role="button"` div without Space/Enter handlers is broken.
 4. **Don't set `role="presentation"` or `aria-hidden="true"` on focusable elements.** You will hide controls from the very users who need them.
-5. **Every interactive element needs an accessible name.** Use a visible label, `aria-label`, or `aria-labelledby`.
+
+One more requirement sits outside that list but is enforced by WCAG all the same: every interactive element needs an accessible name — a visible label, `aria-label`, or `aria-labelledby`.
 
 Common, useful ARIA attributes:
 


### PR DESCRIPTION
## What changed

`src/content/spec/accessibility/aria-usage.md`:

- **Source swap.** Replaced `https://www.w3.org/TR/using-aria/` with **[ARIA in HTML](https://www.w3.org/TR/html-aria/)**. The page keeps four sources.
- **Corrected a factual claim.** The body said "The W3C's own guide leads with five rules". The guide has **four** numbered Rules of ARIA Use. The accessible-name requirement (previously listed as rule 5) is kept, but attributed to WCAG 4.1.2 — which the page already cites — rather than to that list.
- **New short paragraph** in `## Why it matters` on the element-by-element conformance table, with three verified examples: `role="button"` on `<a href>` is permitted; `<textarea>` accepts no role other than `textbox`; `<input type="hidden">` accepts no `role` or `aria-*` at all.

## Why now

Two things moved under this page:

1. **"Using ARIA" was marked a Discontinued Draft on 24 February 2026.** Its own status section now reads: "Using ARIA is a Discontinued Draft. the four rules of ARIA are kept for historical purposes and for easier reference, but there are no plans to continue work on this document." We were citing it as live W3C guidance.
2. **ARIA in HTML reached W3C Recommendation on 15 April 2026** (CR → REC). It is the normative specification of which ARIA roles, states, and properties are valid on which HTML elements — precisely the ground the discontinued draft used to cover, and precisely what this page's "reach for native HTML first" argument rests on.

## Primary sources

- [ARIA in HTML](https://www.w3.org/TR/html-aria/) — W3C Recommendation, 15 April 2026.
- [Using ARIA](https://www.w3.org/TR/using-aria/) — Discontinued Draft, 24 February 2026 (the citation being retired).

## Status

Unchanged: `recommended`. Nothing about the platform contract moved — this is a citation-accuracy and factual-accuracy repair, not a promotion.

## Notes

- Page count and categories unchanged, so no `SKILL.md` / digest work. `npm run build` passes; the pre-commit skill-drift check is green (164 pages, 10 categories).
- No changelog entry included. It sits on the borderline described in `CLAUDE.md` — more than a typo fix (a factual claim in the body changed), less than a substantive rewrite. Flagging rather than deciding: say the word and I will add a `changed` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)