### PR TITLE
docs(changelog): date entries by when they land, add the two missing ones

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,9 @@ When in doubt, default to `recommended`, not `required`. The bar for `required` 
 
 **Always link to the page(s) inline.** An "added a page on X" entry must link X to its `/spec/<category>/<slug>/` URL _in the sentence_ — never trail off with a link to the `/spec/` index. List every page added, each linked.
 
-Do **not** log: typo fixes, refactors, CI/tooling, dependency bumps, OG tweaks, new analytics events, header changes, or any site behaviour invisible on a spec page. Use real dates (British English in the body) and keep each entry to one-to-three sentences.
+Do **not** log: typo fixes, refactors, CI/tooling, dependency bumps, OG tweaks, new analytics events, header changes, or any site behaviour invisible on a spec page. British English in the body, and keep each entry to one-to-three sentences.
+
+**`date` is the day the entry lands on `main`, not the day it was written or the day the underlying standard moved.** This is _our site's_ changelog: it records when this spec changed, not when the world did. A PR authored on the 23rd and merged on the 31st is dated the 31st — so if a PR sits for a few days, re-date the entry (and rename the file to match) before merging. Mention the standard's own date in the body if it matters. The filename is `<date>-<slug>.md` and its stem becomes `entry.id`, which is both the `<li>` anchor on `/changelog/` and the `#`-link in the RSS feed — so renaming an entry that is already live re-delivers it to subscribers as a new item. Re-date before merging, not after.
 
 **When you are unsure whether a change warrants an entry, ask the user — do not silently skip it.** The clear-cut cases decide themselves (a new page always gets one; a typo fix never does). For anything in between — a partial rewrite, a citation overhaul, a reworded summary, a status nuance that isn't a full promotion/downgrade — surface it: _"This change to X is borderline for the changelog — log it as a `changed` entry, or leave it out?"_ and let them call it.
 

--- a/src/content/changelog/2026-07-31-aipref-attach-expired.md
+++ b/src/content/changelog/2026-07-31-aipref-attach-expired.md
@@ -1,0 +1,8 @@
+---
+title: Half of the AI-preferences work has stalled, and the page says so
+date: "2026-07-31"
+type: changed
+relatedSlugs: [content-signals, robots-for-ai-crawlers]
+---
+
+The IETF vocabulary draft behind AI content preferences is alive, but the attachment draft — the half that would define how a site binds those preferences to content over HTTP — expired on 1 May 2026 and has not been reposted. [Content signals](/spec/agent-readiness/content-signals/) now separates the two, so the page is honest that the `robots.txt` line you can write today rests on the IAB Tech Lab specification and validator convention rather than a live IETF draft.

--- a/src/content/changelog/2026-07-31-aria-in-html.md
+++ b/src/content/changelog/2026-07-31-aria-in-html.md
@@ -1,0 +1,8 @@
+---
+title: The four rules of ARIA, and the document that is now normative
+date: "2026-07-31"
+type: changed
+relatedSlugs: [aria-usage, semantic-html]
+---
+
+"Using ARIA" became a Discontinued Draft in February 2026, and it lists four rules — not the five [ARIA — first rule of ARIA](/spec/accessibility/aria-usage/) claimed. The page now cites [ARIA in HTML](https://www.w3.org/TR/html-aria/), which reached W3C Recommendation on 15 April 2026 and is the normative statement of which roles are valid on which elements; the answers are not always the intuitive ones, since `role="button"` on an `<a href>` is permitted while `<textarea>` accepts no role other than the `textbox` it already has.

--- a/src/content/changelog/2026-07-31-mcp-handshake.md
+++ b/src/content/changelog/2026-07-31-mcp-handshake.md
@@ -1,6 +1,6 @@
 ---
 title: MCP dropped the handshake, so the page describing it had to change
-date: "2026-07-28"
+date: "2026-07-31"
 type: changed
 relatedSlugs: [mcp-and-tool-discovery, deprecation-and-sunset, agent-readiness-overview]
 ---

--- a/src/content/changelog/2026-07-31-tdmrep.md
+++ b/src/content/changelog/2026-07-31-tdmrep.md
@@ -1,6 +1,6 @@
 ---
 title: Reserving mining rights is a legal act, not a crawler block
-date: "2026-07-28"
+date: "2026-07-31"
 type: added
 relatedSlugs: [tdmrep, content-signals, robots-for-ai-crawlers]
 ---

--- a/src/content/changelog/2026-07-31-websub.md
+++ b/src/content/changelog/2026-07-31-websub.md
@@ -1,6 +1,6 @@
 ---
 title: Added a page on WebSub
-date: "2026-07-30"
+date: "2026-07-31"
 type: added
 relatedSlugs: [websub]
 ---


### PR DESCRIPTION
The changelog records when *this spec* changed, not when the world did — so `date` is the day the entry lands on `main`.

## Re-dated three entries

All three merged today, but carried the date their PR was authored:

| Entry | Was | Now |
| --- | --- | --- |
| `tdmrep` | 28 July | 31 July |
| `mcp-2026-07-28` → `mcp-handshake` | 28 July | 31 July |
| `websub` | 30 July | 31 July |

`ard-catalog-unsigned` was already 31 July.

**Renaming is not free, which is why now.** The filename stem is `entry.id`, and that is both the `<li>` anchor on `/changelog/` and the `#`-link the RSS feed emits — so renaming a live entry re-delivers it to subscribers as a new item. These three have been live for under an hour, so the churn is as small as it is ever going to be. I verified the six anchors in the built `dist/changelog/index.html` match the six `<link>`s in `dist/changelog/rss.xml` exactly.

I also renamed `2026-07-28-mcp-2026-07-28.md` to `2026-07-31-mcp-handshake.md` — the old name carried two dates meaning different things, which is exactly the confusion this PR is fixing.

## Two new entries

**[ARIA in HTML](src/content/changelog/2026-07-31-aria-in-html.md)** (`changed`) — covers #138. "Using ARIA" was discontinued and lists four rules, not the five the page claimed; ARIA in HTML reached Recommendation on 15 April 2026.

**[aipref attachment draft](src/content/changelog/2026-07-31-aipref-attach-expired.md)** (`changed`) — covers #131, which merged unlogged. I under-called this at the time: it is not a citation repair. It replaced one paragraph with three and changed what the page says about the topic's standing — the same shape as the MCP entry that was logged.

## Deliberately not logged

- **#122 (WebMCP lazy load)** — the only body change was the "this site ships it" callout gaining a sentence about the guard. The recommendation did not move. Logging it would mean every performance tweak earns an entry.
- **#141 (WebSub self-hub)** — plumbing, and the hub is inert until D1 is provisioned. The WebSub `added` entry already covers the page; better to extend its body once the hub is actually live.

## CLAUDE.md

The dating rule is now written down, along with the reason renaming a live entry has a cost, so the next agent re-dates *before* merging rather than after.

## Checks

`npm run build` ✓ · `npm run format:check` ✓ · `npm run check:skill` ✓ (166 pages) · anchors verified against feed links in the built output

🤖 Generated with [Claude Code](https://claude.com/claude-code)