### PR TITLE
feat(websub): advertise the hub on both feeds

### DIFF
--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -26,6 +26,12 @@
           "title": "Changelog feed"
         }
       ],
+      "hub": [
+        {
+          "href": "https://specification.website/websub",
+          "title": "WebSub hub for this site's feeds"
+        }
+      ],
       "sitemap": [
         {
           "href": "https://specification.website/sitemap-index.xml",

--- a/public/_headers
+++ b/public/_headers
@@ -64,23 +64,19 @@
   Content-Type: text/javascript; charset=utf-8
   Cache-Control: public, max-age=600, must-revalidate
 
-# Feeds — WebSub discovery. HELD BACK UNTIL THE HUB IS LIVE: advertising
-# rel="hub" while /websub cannot accept subscriptions is the exact failure
-# /spec/foundations/websub/ warns about (an advertisement is not a delivery
-# mechanism), so these blocks are uncommented in the same commit that
-# provisions the D1 database — see the checklist in wrangler.toml.
+# Feeds — WebSub discovery.
 #
 # rel="hub" names the hub that pushes updates for this topic; rel="self" is the
 # topic's canonical URL, which is the identity subscribers key on. Subscribers
 # must check Link headers before embedded elements (WebSub §4), so this is the
 # authoritative copy and the atom:link elements inside each feed are the
 # fallback. Keep all three in sync with ALLOWED_TOPICS in functions/websub.ts.
-#
-# /rss.xml
-#   Link: </websub>; rel="hub", <https://specification.website/rss.xml>; rel="self"
-#
-# /changelog/rss.xml
-#   Link: </websub>; rel="hub", <https://specification.website/changelog/rss.xml>; rel="self"
+
+/rss.xml
+  Link: </websub>; rel="hub", <https://specification.website/rss.xml>; rel="self"
+
+/changelog/rss.xml
+  Link: </websub>; rel="hub", <https://specification.website/changelog/rss.xml>; rel="self"
 
 # Long cache for fingerprinted assets
 /_astro/*

--- a/src/content/spec/foundations/websub.md
+++ b/src/content/spec/foundations/websub.md
@@ -7,7 +7,7 @@ status: optional
 order: 130
 appliesTo: [all]
 relatedSlugs: [feed-discovery, feed-hygiene, canonical-url, link-headers]
-updated: "2026-07-30T00:00:00.000Z"
+updated: "2026-07-31T00:00:00.000Z"
 sources:
   - title: "WebSub — W3C Recommendation, 2 June 2026"
     url: "https://www.w3.org/TR/websub/"
@@ -61,6 +61,8 @@ Or, inside an Atom feed:
 **3. Run or choose a hub.** You can operate one, or point at a hosted hub. Either way the hub is a real service with obligations: it verifies every subscription with a `hub.challenge` handshake, enforces lease expiry via `hub.lease_seconds`, and must not issue perpetual leases. If a subscriber supplied a `hub.secret`, the hub signs each delivery with `X-Hub-Signature`, in the form `method=signature` — `sha256`, `sha384`, and `sha512` are the algorithms to use; `sha1` is still recognised but has no business in new deployments.
 
 **4. Keep the feed correct anyway.** WebSub is additive. Subscribers that do not implement it keep polling, so [feed hygiene](/spec/foundations/feed-hygiene/) — stable GUIDs, valid markup, correct `Last-Modified` and `ETag` — still governs how well those clients behave. The push path carries the same feed body, so a malformed feed is malformed for everyone.
+
+**This site ships it.** Both [`/rss.xml`](/rss.xml) and [`/changelog/rss.xml`](/changelog/rss.xml) advertise `rel="hub"` and `rel="self"` on the response and inside the feed, pointing at a hub we run ourselves at `/websub`. It is deliberately a *self-hub*: `hub.topic` is allowlisted to those two feeds, so the endpoint cannot be pointed at arbitrary URLs or made to relay anyone else's content. An open hub is a public service with a different risk profile, and running one is not a prerequisite for the advice above — pointing at a hosted hub is the ordinary choice.
 
 ## Common mistakes
 

--- a/src/pages/changelog/rss.xml.ts
+++ b/src/pages/changelog/rss.xml.ts
@@ -56,9 +56,9 @@ export async function GET(context: APIContext) {
     customData: [
       "<language>en-GB</language>",
       `<atom:link href="${feedUrl}" rel="self" type="application/rss+xml" />`,
-      // WebSub hub for this topic — held back until the hub is live, along with
-      // the Link header in public/_headers. See the checklist in wrangler.toml.
-      // `<atom:link href="${base}/websub" rel="hub" />`,
+      // WebSub hub for this topic. Fallback copy of the Link header in
+      // public/_headers — subscribers check headers first (WebSub §4).
+      `<atom:link href="${base}/websub" rel="hub" />`,
       `<lastBuildDate>${lastBuild.toUTCString()}</lastBuildDate>`,
       "<sy:updatePeriod>weekly</sy:updatePeriod>",
       "<sy:updateFrequency>1</sy:updateFrequency>",

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -34,9 +34,9 @@ export async function GET(context: APIContext) {
     customData: [
       "<language>en-GB</language>",
       `<atom:link href="${feedUrl}" rel="self" type="application/rss+xml" />`,
-      // WebSub hub for this topic — held back until the hub is live, along with
-      // the Link header in public/_headers. See the checklist in wrangler.toml.
-      // `<atom:link href="${new URL("/websub", siteUrl).toString()}" rel="hub" />`,
+      // WebSub hub for this topic. Fallback copy of the Link header in
+      // public/_headers — subscribers check headers first (WebSub §4).
+      `<atom:link href="${new URL("/websub", siteUrl).toString()}" rel="hub" />`,
       `<lastBuildDate>${lastBuild.toUTCString()}</lastBuildDate>`,
       "<sy:updatePeriod>weekly</sy:updatePeriod>",
       "<sy:updateFrequency>1</sy:updateFrequency>",


### PR DESCRIPTION
Steps 5 and 6 of the go-live checklist in `wrangler.toml`. The D1 binding landed separately in c588a61, so the hub can actually serve subscriptions — **this is the commit that makes it discoverable.**

Order matters here and this is the safe direction. A `rel="hub"` link with nothing behind it is the exact failure [the spec page](src/content/spec/foundations/websub.md) names: *"an advertisement is not a delivery mechanism."* Binding first, advertisement second.

## What changed

- **[`public/_headers`](public/_headers)** — `rel="hub"` and `rel="self"` on `/rss.xml` and `/changelog/rss.xml`. This is the authoritative copy; subscribers check headers before embedded elements (WebSub §4).
- **[`src/pages/rss.xml.ts`](src/pages/rss.xml.ts)** and **[`src/pages/changelog/rss.xml.ts`](src/pages/changelog/rss.xml.ts)** — the `<atom:link rel="hub">` fallback inside each feed body.
- **[`api-catalog`](public/.well-known/api-catalog)** — a `hub` linkset entry.
- **[`websub.md`](src/content/spec/foundations/websub.md)** — the worked-example callout CLAUDE.md requires once the site is an example of its own page. It says explicitly that this is a *self*-hub with `hub.topic` allowlisted to our two feeds, and that pointing at a hosted hub is the ordinary choice — so the page doesn't read as "you should run one too". `updated` bumped.

## Consistency check

`_headers` warns to keep three copies of the topic list in sync. `ALLOWED_TOPICS` in [`functions/websub.ts`](functions/websub.ts) lists exactly the two `rel="self"` URLs now advertised. All three agree.

## Checks

`npm run build` ✓ · `npm run lint` ✓ · `npm run format:check` ✓ · `npm run test:websub` ✓ · `npm run check:skill` ✓ (166 pages)

Verified in the **built** output rather than the source: both `dist/rss.xml` and `dist/changelog/rss.xml` carry `<atom:link href="https://specification.website/websub" rel="hub"/>`, and `api-catalog` re-parses as valid JSON.

## Still to do after merge (step 7)

- I'll `curl -sI https://specification.website/rss.xml` once Pages deploys and confirm the `Link` header carries `rel="hub"` in production.
- A manual `workflow_dispatch` run of `websub-ping` should return 202 — yours, since it needs the Actions secret and fans out to any live subscribers.
- **`subscribe → verify → distribute` has still never been exercised end to end.** Neither check above proves a real handshake. [websub.rocks](https://websub.rocks/) pointed at `/websub` would.

🤖 Generated with [Claude Code](https://claude.com/claude-code)