### PR TITLE
fix(citations): repair 5 drifted links in performance

### DIFF
--- a/src/content/spec/performance/cache-control.md
+++ b/src/content/spec/performance/cache-control.md
@@ -7,7 +7,7 @@ status: required
 order: 50
 appliesTo: [all]
 relatedSlugs: [compression, core-web-vitals, no-vary-search, conditional-requests, compression-dictionary-transport]
-updated: "2026-06-08T20:15:00.000Z"
+updated: "2026-08-01T00:00:00.000Z"
 sources:
   - title: "RFC 9111 — HTTP Caching"
     url: "https://www.rfc-editor.org/rfc/rfc9111"
@@ -19,7 +19,7 @@ sources:
     url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control"
     publisher: "MDN"
   - title: "MDN — HTTP caching"
-    url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Caching"
     publisher: "MDN"
   - title: "MDN — Vary"
     url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Vary"

--- a/src/content/spec/performance/font-loading.md
+++ b/src/content/spec/performance/font-loading.md
@@ -7,16 +7,16 @@ status: recommended
 order: 70
 appliesTo: [all]
 relatedSlugs: [preload-prefetch-preconnect, critical-css, core-web-vitals, text-wrap]
-updated: "2026-05-29T20:27:54.000Z"
+updated: "2026-08-01T00:00:00.000Z"
 sources:
   - title: "MDN — @font-face"
-    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face"
+    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@font-face"
     publisher: "MDN"
   - title: "web.dev — Best practices for fonts"
     url: "https://web.dev/articles/font-best-practices"
     publisher: "web.dev"
   - title: "MDN — font-display"
-    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display"
+    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@font-face/font-display"
     publisher: "MDN"
   - title: "web.dev — Avoid invisible text during font loading"
     url: "https://web.dev/articles/avoid-invisible-text"

--- a/src/content/spec/performance/scroll-driven-animations.md
+++ b/src/content/spec/performance/scroll-driven-animations.md
@@ -7,19 +7,19 @@ status: optional
 order: 125
 appliesTo: [all]
 relatedSlugs: [view-transitions, core-web-vitals, visibility-aware-rendering, reduced-motion]
-updated: "2026-05-29T16:40:22.000Z"
+updated: "2026-08-01T00:00:00.000Z"
 sources:
   - title: "CSS Scroll-driven Animations Module Level 1"
     url: "https://drafts.csswg.org/scroll-animations-1/"
     publisher: "W3C"
   - title: "MDN — CSS scroll-driven animations"
-    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_scroll-driven_animations"
+    url: "https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Scroll-driven_animations"
     publisher: "MDN"
   - title: "MDN — animation-timeline"
     url: "https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/animation-timeline"
     publisher: "MDN"
   - title: "Chrome for Developers — Scroll-driven animations"
-    url: "https://developer.chrome.com/articles/scroll-driven-animations"
+    url: "https://developer.chrome.com/docs/css-ui/scroll-driven-animations"
     publisher: "Google"
 ---
 


### PR DESCRIPTION
## What changed

Five source URLs in the `performance` category pointed at paths that have since moved. Each replacement was resolved through the MDN MCP server (or followed to its redirect target for the Chrome one), so these are the current canonical URLs, not guesses.

| Page | Old | New |
| --- | --- | --- |
| `font-loading` | `Web/CSS/@font-face` | `Web/CSS/Reference/At-rules/@font-face` |
| `font-loading` | `Web/CSS/@font-face/font-display` | `Web/CSS/Reference/At-rules/@font-face/font-display` |
| `scroll-driven-animations` | `Web/CSS/CSS_scroll-driven_animations` | `Web/CSS/Guides/Scroll-driven_animations` |
| `scroll-driven-animations` | `developer.chrome.com/articles/scroll-driven-animations` | `developer.chrome.com/docs/css-ui/scroll-driven-animations` |
| `cache-control` | `Web/HTTP/Caching` | `Web/HTTP/Guides/Caching` |

## Why now

Daily standards scan, 2026-08-01. The rotating citation slice covered `performance` and `seo` this run. MDN has grown a `Reference/` layer under `Web/CSS` and a `Guides/` layer under `Web/HTTP` and `Web/CSS` — the same reorg that produced #129, #130 and #135. All 30-odd `seo` citations checked clean; these five were the only misses.

The old URLs still resolve via redirect rather than 404, so nothing was visibly broken — but a redirect is a citation one reorg away from being dead, and the point of citing a primary reference is that the link keeps pointing at the thing.

## Sources

Current canonical paths per the [MDN MCP server](https://mcp.mdn.mozilla.net/); the Chrome page's own redirect target.

## Status

No status changes. Citation-only repair, so no changelog entry (per CLAUDE.md). `updated` bumped on all three pages. `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)