### PR TITLE
add(considered): the _for-sale DNS node name is about the domain, not the site

### DIFF
--- a/src/content/considered/for-sale-dns-node-name.md
+++ b/src/content/considered/for-sale-dns-node-name.md
@@ -1,0 +1,19 @@
+---
+title: 'The "_for-sale" DNS node name (RFC 10023)'
+date: "2026-08-02"
+reason: too-narrow
+revisit: "Registrars, parking providers or domain marketplaces publishing it by default, and buyer-side tooling reading it. At that point it becomes a discovery convention with an audience, and the page would sit alongside the other DNS-level signals."
+sources:
+  - title: 'RFC 10023 — The "_for-sale" Underscored and Globally Scoped DNS Node Name'
+    url: "https://www.rfc-editor.org/rfc/rfc10023.html"
+    publisher: "IETF"
+  - title: "RFC 8552 — Scoped Interpretation of DNS Resource Records through Underscored Node Names"
+    url: "https://www.rfc-editor.org/rfc/rfc8552"
+    publisher: "IETF"
+---
+
+RFC 10023, published as Informational in July 2026 by SIDN Labs, reserves the underscored node name `_for-sale` so a domain holder can advertise that the parent domain is available for purchase. A TXT record at `_for-sale.example.com` carries tag-value pairs — `ftxt=` for human-readable text, `furi=` for a contact URI, `fval=` for an asking price, `fcod=` for a proprietary code. It needs no protocol change and can sit on a domain that is still in active use.
+
+It is externally checkable, which is the test this spec normally applies to DNS-level conventions, and on that count it passes where an HTTP method or a CSS feature would not. What it does not pass is the question of who it is for. Every other signal we spec — CAA, DNSSEC, DNS-AID — tells a visitor, a resolver or an agent something about the site that is there. This one tells a prospective buyer something about the domain, which is a fact about a commercial transaction happening beside the website rather than a property of the website. A good website is not improved by being for sale.
+
+Adoption is the second problem and currently the simpler one: the RFC documents a proposed convention rather than an established practice, and states no deployments. Both objections would have to fall away together — a registrar ecosystem publishing it, and a reason to describe it as something a site does rather than something its owner does — before this is a page. The narrow-audience objection is the one that would need the better argument.


### PR DESCRIPTION
## What changed

Adds [`src/content/considered/for-sale-dns-node-name.md`](src/content/considered/for-sale-dns-node-name.md) — one entry on `/considered/`, no spec page, nothing else touched.

## Why now

**RFC 10023 — The "\_for-sale" Underscored and Globally Scoped DNS Node Name**, Informational, **July 2026**, from SIDN Labs (https://www.rfc-editor.org/rfc/rfc10023.html). It reserves `_for-sale` so a TXT record at `_for-sale.example.com` can advertise that the parent domain is available for purchase, using `ftxt=` / `furi=` / `fval=` / `fcod=` tag-value pairs. No protocol change required, and it works on a domain still in active use.

## Why it is not a page

Two reasons, recorded in that order because they are not equally strong.

1. **Audience.** It is externally checkable, so it clears the bar an HTTP method or a CSS authoring feature would not. But every other DNS-level signal we spec — CAA, DNSSEC, DNS-AID — tells a visitor, resolver or agent something about the site that is there. This one tells a prospective buyer something about the domain. That is a fact about a commercial transaction happening beside the website, not a property of the website.
2. **Adoption.** The RFC documents a proposed convention and states no deployments. Three days old at time of writing.

Filed as **`too-narrow`** rather than `too-early`, because adoption is the easier of the two to reverse — a registrar ecosystem could publish this next quarter and it still would not be something a good website does. `revisit` says both would have to give.

## Maintainer call

This is the one I would most expect you to overrule. If you read `_for-sale` as belonging next to the other DNS records we cover, the counter-argument is decent: it is a well-known-style convention, it is registered, and "the domain you are looking at is available" is genuinely useful information to the person looking. Say so and I will write the page instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
