### PR TITLE
fix(citations): the FAQ rich result doc is gone; cite the changelog and schema.org

### DIFF
--- a/src/content/spec/seo/structured-data.md
+++ b/src/content/spec/seo/structured-data.md
@@ -7,13 +7,13 @@ status: recommended
 order: 100
 appliesTo: [all]
 relatedSlugs: [breadcrumbs, heading-hierarchy, xml-sitemaps, canonical-url, schemamap, server-side-rendering]
-updated: "2026-07-09T00:00:00.000Z"
+updated: "2026-08-03T00:00:00.000Z"
 sources:
   - title: "Schema.org"
     url: "https://schema.org/"
     publisher: "schema.org"
-  - title: "FAQPage (FAQ) structured data"
-    url: "https://developers.google.com/search/docs/appearance/structured-data/faqpage"
+  - title: "Latest Google Search documentation updates"
+    url: "https://developers.google.com/search/updates"
     publisher: "Google Search Central"
   - title: "Introduction to structured data markup in Google Search"
     url: "https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data"
@@ -69,7 +69,7 @@ Stick to a small set of well-supported types:
 - **`BreadcrumbList`** — on every page that has a breadcrumb trail.
 - **`Article`** or **`BlogPosting`** — for articles, with `headline`, `datePublished`, `dateModified`, `author`, `image`.
 - **`Product`**, **`Offer`**, **`AggregateRating`** — for e-commerce, where eligibility is strict.
-- **`FAQPage`** — only when the page genuinely has a Q-and-A list visible to users. Note that Google [retired the FAQ rich result in 2026](https://developers.google.com/search/docs/appearance/structured-data/faqpage): `FAQPage` is still valid schema.org vocabulary, but it no longer produces a Google search feature, and no answer engine has confirmed it favours the markup over rendered HTML — so add it for genuine visible content, not for SERP or "GEO" gain. Never stuff fake FAQs. ([Further reading](https://joost.blog/faq-schema-cycle/) on why the format was abused into deprecation, and the proposed `FAQSection` type for Q-and-A that is a *section* of a page rather than its main entity.)
+- **`FAQPage`** — only when the page genuinely has a Q-and-A list visible to users. Google [stopped showing the FAQ rich result on 7 May 2026 and deleted its documentation on 15 June 2026](https://developers.google.com/search/updates): [`FAQPage`](https://schema.org/FAQPage) is still valid schema.org vocabulary, but it no longer produces a Google search feature, and no answer engine has confirmed it favours the markup over rendered HTML — so add it for genuine visible content, not for SERP or "GEO" gain. Never stuff fake FAQs. ([Further reading](https://joost.blog/faq-schema-cycle/) on why the format was abused into deprecation, and the proposed `FAQSection` type for Q-and-A that is a *section* of a page rather than its main entity.)
 
 Rules:
 


### PR DESCRIPTION
## What changed

[`seo/structured-data`](https://specification.website/spec/seo/structured-data/) cited `https://developers.google.com/search/docs/appearance/structured-data/faqpage` twice — once in frontmatter `sources`, once as the inline link behind "retired the FAQ rich result in 2026". **That URL no longer exists**; it now soft-redirects to the Search Central changelog.

- Frontmatter source → [Latest Google Search documentation updates](https://developers.google.com/search/updates) (same publisher, and the page that actually carries the evidence).
- Inline link split in two: the changelog for the retirement claim, [schema.org/FAQPage](https://schema.org/FAQPage) for "still valid schema.org vocabulary".
- The retirement dates are now stated in the prose rather than left to the link, so the claim survives the changelog entry scrolling off.
- `updated` bumped.

## Why now

Found by this run's rotating citation slice (`well-known` + `seo`, ~48 source URLs). It was the only dead citation in the slice.

## Primary sources

Google Search Central's documentation changelog carries both entries:

- **8 May 2026** — "Added a deprecation notice to the FAQ rich result documentation… This feature will no longer appear in Google Search starting May 7, 2026."
- **15 June 2026** — "Removed documentation for the FAQ rich result feature… The FAQ rich result feature is no longer shown in Google Search results, as announced in the changelog entry in May 2026."

Corroborated by the [structured data markup gallery](https://developers.google.com/search/docs/appearance/structured-data/search-gallery), which no longer lists FAQ among its 30 features.

## Status

Unchanged (`recommended`). This is a citation repair, not a content change — the page's prose was already correct that Google retired the feature, so no changelog entry (consistent with #147, #135, #130, #129).

`npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)