### PR TITLE
fix(citations): the 2011 planned-downtime post is gone from Search Central

### DIFF
--- a/src/content/spec/resilience/maintenance-pages.md
+++ b/src/content/spec/resilience/maintenance-pages.md
@@ -7,7 +7,7 @@ status: recommended
 order: 20
 appliesTo: [all]
 relatedSlugs: [error-pages, monitoring-uptime, graceful-degradation, robots-for-ai-crawlers]
-updated: "2026-06-08T20:15:00.000Z"
+updated: "2026-08-04T00:00:00.000Z"
 sources:
   - title: "RFC 9110 — HTTP Semantics: 503 Service Unavailable"
     url: "https://www.rfc-editor.org/rfc/rfc9110.html#name-503-service-unavailable"
@@ -18,8 +18,8 @@ sources:
   - title: "RFC 6585 — Additional HTTP Status Codes: 429 Too Many Requests"
     url: "https://www.rfc-editor.org/rfc/rfc6585#section-4"
     publisher: "IETF"
-  - title: "Google Search Central — How to deal with planned site downtime"
-    url: "https://developers.google.com/search/blog/2011/01/how-to-deal-with-planned-site-downtime"
+  - title: "Google Search Central — Temporarily pause or disable a website"
+    url: "https://developers.google.com/search/docs/crawling-indexing/pause-online-business"
     publisher: "Google Search Central"
 ---
 


### PR DESCRIPTION
## What changed

[`src/content/spec/resilience/maintenance-pages.md`](src/content/spec/resilience/maintenance-pages.md) cited a January 2011 Webmaster Central blog post for the "return 503 with Retry-After during planned downtime" advice:

```
https://developers.google.com/search/blog/2011/01/how-to-deal-with-planned-site-downtime
```

That path no longer resolves to an article. It lands on the Search Central blog index, whose archive only goes back to 2012 — the pre-migration Webmaster Central posts were not all carried over. (The original still exists on the retired `webmasters.googleblog.com` host, but citing a decommissioned blog host for advice Google now documents properly would be the worse fix.)

## Why now

Daily standards scan, citation rotation over `i18n/` and `resilience/` — the two categories not spot-checked in the last week.

## The replacement

[Google Search Central — Temporarily pause or disable a website](https://developers.google.com/search/docs/crawling-indexing/pause-online-business) is the current, maintained documentation on the same subject. It carries the same guidance the page makes ("return an informational error page with a 503 HTTP response status code", use `Retry-After` with an expected recovery date), so the claim the citation supports is unchanged.

`updated` bumped per the convention in the other citation-repair PRs. No body change; the other three sources (RFC 9110 ×2, RFC 6585) are fine.

## Noted but not bundled

The replacement doc adds a nuance the page does not currently make: **do not return 503 for `robots.txt` itself** during an outage. That is a real content addition rather than a citation repair, so it is left out of this PR — flagged in the scan summary instead.

`npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)