### PR TITLE
fix(citations): NLWeb moved out of the microsoft org to nlweb-ai

### DIFF
--- a/src/content/spec/agent-readiness/nlweb.md
+++ b/src/content/spec/agent-readiness/nlweb.md
@@ -9,12 +9,12 @@ appliesTo: [all]
 relatedSlugs: [mcp-and-tool-discovery, agent-readiness-overview, structured-data-for-agents, link-headers]
 updated: "2026-05-29T12:14:17.000Z"
 sources:
-  - title: "microsoft/NLWeb on GitHub"
-    url: "https://github.com/microsoft/NLWeb"
-    publisher: "Microsoft"
+  - title: "nlweb-ai/NLWeb on GitHub"
+    url: "https://github.com/nlweb-ai/NLWeb"
+    publisher: "NLWeb project"
   - title: "NLWeb — REST API"
-    url: "https://github.com/microsoft/NLWeb/blob/main/docs/nlweb-rest-api.md"
-    publisher: "Microsoft"
+    url: "https://github.com/nlweb-ai/NLWeb/blob/main/docs/nlweb-rest-api.md"
+    publisher: "NLWeb project"
   - title: "schema.org"
     url: "https://schema.org/"
     publisher: "schema.org"
@@ -22,7 +22,7 @@ sources:
 
 ## What it is
 
-NLWeb is an open project, originally from Microsoft, that lets any website expose a conversational query interface in a standard way. A site implements a small HTTP endpoint — by convention `/ask` — that accepts a natural-language query and returns a structured answer grounded in the site's own content, typically built from its [schema.org](https://schema.org/) data and embeddings of its pages.
+NLWeb is an open project, originally from Microsoft and now developed in its own `nlweb-ai` organisation, that lets any website expose a conversational query interface in a standard way. A site implements a small HTTP endpoint — by convention `/ask` — that accepts a natural-language query and returns a structured answer grounded in the site's own content, typically built from its [schema.org](https://schema.org/) data and embeddings of its pages.
 
 Discovery is one HTML link tag:
 
@@ -39,7 +39,7 @@ An agent that recognises the relation knows the site speaks NLWeb without furthe
 - **Composes with [MCP](/spec/agent-readiness/mcp-and-tool-discovery/).** The NLWeb endpoint can also be exposed as an `ask_site` MCP tool. Same logic, two transports.
 - **Cheap to ship.** A static site with [structured data](/spec/agent-readiness/structured-data-for-agents/) and a small vector index can answer most factual questions about its own content without a chatbot UI.
 
-The convention is early and mostly Microsoft-driven so far, but the discovery link is a single line in `<head>` and the endpoint shape is documented. Treat NLWeb as `optional` — recommended where the site already has the corpus to ground answers, skippable for small static sites.
+The convention is still early and driven by a single project, but the discovery link is a single line in `<head>` and the endpoint shape is documented. Treat NLWeb as `optional` — recommended where the site already has the corpus to ground answers, skippable for small static sites.
 
 ## How to implement
 


### PR DESCRIPTION
## What changed

Two source URLs and both publisher fields on [`agent-readiness/nlweb`](https://specification.website/spec/agent-readiness/nlweb/), plus two clauses of prose that asserted Microsoft ownership.

- `github.com/microsoft/NLWeb` → `github.com/nlweb-ai/NLWeb`
- `github.com/microsoft/NLWeb/blob/main/docs/nlweb-rest-api.md` → same path under `nlweb-ai`
- `publisher: "Microsoft"` → `publisher: "NLWeb project"` on both sources

## Why now

Rotating-slice citation check for the daily standards scan — this run covered `agent-readiness` (all 55 distinct source URLs) plus the non-IETF sources in `well-known`.

The NLWeb reference implementation has moved out of the `microsoft` org into a dedicated `nlweb-ai` org. GitHub still redirects the old paths, so neither citation 404s and the **Internal links** / external-link jobs would not have caught this — but the cited URL and the publisher attribution are both wrong now.

The README still carries Microsoft's trademark guidance and `NLWebSup@microsoft.com` as the support contact, so "originally from Microsoft" in `## What it is` stays true; it now says the project is developed in its own organisation. The sentence in `## Why it matters` that called the convention "mostly Microsoft-driven" is now "driven by a single project", which is the claim the evidence actually supports.

## Sources verified today

- <https://github.com/nlweb-ai/NLWeb> — 6.2k stars, "Main reference implementation for NLWeb, implemented in Python"
- <https://github.com/nlweb-ai/NLWeb/blob/main/docs/nlweb-rest-api.md> — `/ask` and `/mcp` endpoints, list/summarize/generate modes, schema.org `ItemList` responses — matches what the page describes

## Status

Unchanged (`optional`). Nothing about the move changes the adoption picture.

`updated` deliberately left alone: `/rss.xml` sorts and dates items by `updated`, so bumping it re-delivers the page to subscribers, and a source-URL repair is not a content change. Same convention as #147, #156, #158, #160.

`npm run build` passes.
