### PR TITLE
fix(citations): pin the MCP authorization link, follow Android's doc move

### DIFF
--- a/src/content/spec/well-known/assetlinks-json.md
+++ b/src/content/spec/well-known/assetlinks-json.md
@@ -7,10 +7,10 @@ status: optional
 order: 60
 appliesTo: [all]
 relatedSlugs: [well-known-overview, apple-app-site-association]
-updated: "2026-06-09T11:30:00.000Z"
+updated: "2026-08-08T00:00:00.000Z"
 sources:
-  - title: "Digital Asset Links — Verify Android App Links"
-    url: "https://developer.android.com/training/app-links/verify-android-applinks"
+  - title: "Verify Android App Links"
+    url: "https://developer.android.com/training/app-links/verify-applinks"
     publisher: "Google Developers"
   - title: "Digital Asset Links protocol"
     url: "https://developers.google.com/digital-asset-links/v1/getting-started"

--- a/src/content/spec/well-known/oauth-protected-resource.md
+++ b/src/content/spec/well-known/oauth-protected-resource.md
@@ -7,7 +7,7 @@ status: optional
 order: 32
 appliesTo: [all]
 relatedSlugs: [openid-configuration, oauth-authorization-server, well-known-overview, mcp-and-tool-discovery, webauthn]
-updated: "2026-07-08T00:00:00.000Z"
+updated: "2026-08-08T00:00:00.000Z"
 sources:
   - title: "RFC 9728 — OAuth 2.0 Protected Resource Metadata"
     url: "https://www.rfc-editor.org/rfc/rfc9728"
@@ -18,8 +18,8 @@ sources:
   - title: "IANA — Well-Known URIs Registry"
     url: "https://www.iana.org/assignments/well-known-uris/well-known-uris.xhtml"
     publisher: "IANA"
-  - title: "Model Context Protocol — Authorization"
-    url: "https://modelcontextprotocol.io/specification/draft/basic/authorization"
+  - title: "Model Context Protocol 2026-07-28 — Authorization"
+    url: "https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization"
     publisher: "Anthropic / MCP"
 ---
 


### PR DESCRIPTION
Rotating citation slice for this run: **well-known** (12 pages, least recently checked — last touched by #134 for NodeInfo). All 12 pages' sources were resolved; two had drifted.

## What changed

**`well-known/oauth-protected-resource.md`** — cited `https://modelcontextprotocol.io/specification/draft/basic/authorization`.

`/specification/draft/` is an alias that re-points at whatever revision is currently in progress, so the citation silently changes meaning under us as MCP iterates. Every other MCP citation in the repo (`mcp-and-tool-discovery.md`, `SKILL.md`, `mcp/src/index.ts`) pins `2026-07-28`. This now matches. Verified the pinned page carries the same normative requirement the page relies on:

> MCP servers **MUST** implement OAuth 2.0 Protected Resource Metadata ([RFC9728]).

**`well-known/assetlinks-json.md`** — cited `https://developer.android.com/training/app-links/verify-android-applinks`.

Google dropped `android-` from the path. The canonical page is now `https://developer.android.com/training/app-links/verify-applinks` ("Verify App Links", last updated 2026-08-07), and it still documents `https://hostname/.well-known/assetlinks.json` as the file Android queries.

Both pages' `updated` bumped. No status or body changes.

## Checked and left alone

The other ten well-known pages resolve correctly and still say what we claim:

- `apple-app-site-association` — both Apple docs live.
- `api-catalog`, `well-known-overview`, `webfinger`, `oauth-authorization-server`, `openid-configuration` — RFC and IANA citations are stable by construction.
- `change-password` — still the 28 January 2021 W3C Editor's Draft; unchanged.
- `webauthn` — `w3.org/TR/webauthn-3/` is W3C's latest-published-version alias, which is the right form. Level 3 is at Candidate Recommendation Snapshot (26 May 2026); `web.dev/articles/webauthn-related-origin-requests` still documents `/.well-known/webauthn`.
- `traffic-advice` — the private-prefetch-proxy repo is active and the Chrome blog post is live.
- `nodeinfo` — fixed recently in #134.

## Not logged in the changelog

Citation repairs are on CLAUDE.md's do-not-log list. No page count or category change, so `SKILL.md` and its digest are untouched (pre-commit confirms: 166 pages, 10 categories, MCP 2026-07-28, digest ✓).

`npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)