### PR TITLE
build(deps): stop Dependabot proposing the typescript major bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,15 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
+    ignore:
+      # @astrojs/check 0.9.10 peers typescript "^5.0.0 || ^6.0.0", so a v7
+      # bump makes `npm ci` fail with ERESOLVE and every job in every
+      # workflow dies at install (#155, #164 — both regenerated weekly and
+      # neither could ever go green). The bump also drags the rest of the
+      # dev-deps group down with it. Re-allow once @astrojs/check widens
+      # its peer range to accept v7.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       astro:
         patterns:


### PR DESCRIPTION
## The problem

`@astrojs/check@0.9.10` declares `peerDependencies: { "typescript": "^5.0.0 || ^6.0.0" }`. Any bump of the root `typescript` to v7 makes `npm ci` fail with `ERESOLVE`, so **every job in every workflow dies at the install step** — not just the type-check.

Because `typescript` falls into the `dev-deps` group, it also drags the other five bumps in that group down with it, so nothing in the group can land.

This has now happened twice:

- **#155** — opened, never went green, closed.
- **#164** — Dependabot regenerated it immediately, fails identically.

Left alone it recurs every Monday, and each run mails a failure while gating nothing.

## The change

Ignore major updates for `typescript` **in the root manifest only**:

```yaml
    ignore:
      - dependency-name: "typescript"
        update-types: ["version-update:semver-major"]
```

Minor and patch updates still flow, so `typescript@6.x` keeps getting bumped.

Same shape and placement as the existing `/mcp` ignore for `@cloudflare/workers-types`, with the same "here is what would re-allow it" comment, so the register of deliberate holds stays readable.

## Scoping

`/mcp` is a separate `updates:` entry and does **not** inherit this — verified by parsing the file. It declares `typescript@^7.0.2` already and has no `@astrojs/check`, so there is no conflict there and no reason to hold it back.

## After this lands

`@dependabot recreate` on #164 so it regenerates honouring the new ignore, which should let the other five dev-deps bumps through on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)