### PR TITLE
docs(deps): correct the stale rationale on the /mcp workers-types ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,9 +35,16 @@ updates:
       day: monday
     open-pull-requests-limit: 5
     ignore:
-      # wrangler's peer range only accepts workers-types v4; a v5 bump
-      # breaks `npm ci` in the Deploy MCP workflow. Re-allow once
-      # wrangler's peerDependencies accept v5.
+      # Standing rule, not a temporary hold: wrangler peers
+      # @cloudflare/workers-types to one specific major, so a workers-types
+      # major that lands before wrangler catches up fails `npm ci` with
+      # ERESOLVE and takes the Deploy MCP workflow with it. Minor and patch
+      # bumps within the current major are unaffected and still flow.
+      # Wrangler moves this range itself; when it does, bump the major here
+      # by hand in the same PR as the wrangler bump. Check with:
+      #   npm view wrangler peerDependencies
+      # (2026-08-08: wrangler 4.118.0 peers ^5.x and /mcp is on 5.x — the
+      # v4 constraint this rule was originally written for is long gone.)
       - dependency-name: "@cloudflare/workers-types"
         update-types: ["version-update:semver-major"]
 


### PR DESCRIPTION
Follow-up to #167. Comments only — the parsed Dependabot rules are unchanged.

## What was wrong

The note on the `/mcp` ignore read:

> wrangler's peer range only accepts workers-types v4; a v5 bump breaks `npm ci` in the Deploy MCP workflow. Re-allow once wrangler's peerDependencies accept v5.

Both halves have expired:

```console
$ npm view wrangler peerDependencies
{ '@cloudflare/workers-types': '^5.20260801.1' }
```

Locally, `wrangler@4.118.0` peers `^5.20260730.1`, and `/mcp` is on `5.20260804.1` — #152 and #168 both landed v5 bumps this week.

## Why the rule still has to stay

Read literally, the note said the hold was finished and the rule could be deleted. It cannot. It is what stops a workers-types **major** landing ahead of whatever major wrangler currently peers — the identical `ERESOLVE` failure, one major later. (No v6 exists yet; published majors are 0–5.)

The actual defect was framing a **standing guard** as a **temporary hold pinned to specific version numbers**, which guaranteed it would rot as soon as the ecosystem moved — and it did, silently, while still looking authoritative.

## The rewrite

- Describes the mechanism instead of a version.
- Says explicitly that it is standing, not pending removal.
- Notes that wrangler moves the range itself, and that the major here should be bumped by hand in the same PR as the wrangler bump.
- Dates the version-specific observation and gives `npm view wrangler peerDependencies` so the next reader verifies instead of trusting.

## Verified

Parsed the YAML before and after: both files yield

```json
[{"dependency-name":"@cloudflare/workers-types","update-types":["version-update:semver-major"]}]
```

Diffing the change with comment lines stripped leaves nothing, so behaviour is identical. `format:check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)