### PR TITLE
fix(aria-usage): ARIA in HTML is an amended REC, not an April 2026 one

### DIFF
--- a/src/content/spec/accessibility/aria-usage.md
+++ b/src/content/spec/accessibility/aria-usage.md
@@ -7,7 +7,7 @@ status: recommended
 order: 80
 appliesTo: [all]
 relatedSlugs: [semantic-html, form-labels, keyboard-navigation]
-updated: "2026-08-12T00:00:00.000Z"
+updated: "2026-08-21T00:00:00.000Z"
 sources:
   - title: "ARIA in HTML (W3C Recommendation)"
     url: "https://www.w3.org/TR/html-aria/"

--- a/src/content/spec/accessibility/aria-usage.md
+++ b/src/content/spec/accessibility/aria-usage.md
@@ -7,9 +7,9 @@ status: recommended
 order: 80
 appliesTo: [all]
 relatedSlugs: [semantic-html, form-labels, keyboard-navigation]
-updated: "2026-07-31T00:00:00.000Z"
+updated: "2026-08-12T00:00:00.000Z"
 sources:
-  - title: "ARIA in HTML (W3C Recommendation, 15 April 2026)"
+  - title: "ARIA in HTML (W3C Recommendation)"
     url: "https://www.w3.org/TR/html-aria/"
     publisher: "W3C"
   - title: "ARIA Authoring Practices Guide — Read Me First"
@@ -31,7 +31,9 @@ ARIA — Accessible Rich Internet Applications — is a set of HTML attributes (
 
 ARIA is a sharp tool. Used well, it lets you describe widgets the HTML spec does not cover. Used badly, it overrides the real semantics of an element and makes the page *less* accessible than the unstyled HTML would have been. The W3C's four rules of ARIA lead with the most important one: reach for native HTML first.
 
-Which roles and attributes are actually *allowed* on a given element is not a matter of taste either. [ARIA in HTML](https://www.w3.org/TR/html-aria/) became a W3C Recommendation in April 2026 and specifies it element by element. The answers are not always the intuitive ones: `role="button"` on an `<a href>` is permitted, while `<textarea>` accepts no role other than the `textbox` it already has, and `<input type="hidden">` accepts no `role` or `aria-*` attribute at all.
+Which roles and attributes are actually *allowed* on a given element is not a matter of taste either. [ARIA in HTML](https://www.w3.org/TR/html-aria/) specifies it element by element. The answers are not always the intuitive ones: `role="button"` on an `<a href>` is permitted, while `<textarea>` accepts no role other than the `textbox` it already has, and `<input type="hidden">` accepts no `role` or `aria-*` attribute at all.
+
+It has been a W3C Recommendation since December 2021, but "Recommendation" here does not mean finished. W3C republishes it as an amended Recommendation whenever the element table changes — several times a year, most recently on 11 August 2026 — so a rule you looked up two years ago may since have been added, narrowed, or dropped. Read the undated `/TR/html-aria/` URL, which always resolves to the current edition, and check the specification's own change log rather than a copy of the table in a blog post or a linter's rule set.
 
 ## How to implement
 


### PR DESCRIPTION
## What changed

[ARIA — first rule of ARIA](https://specification.website/spec/accessibility/aria-usage/):

- The claim "became a W3C Recommendation in April 2026" is wrong. Removed.
- Source title `ARIA in HTML (W3C Recommendation, 15 April 2026)` → `ARIA in HTML (W3C Recommendation)`. The URL is unchanged and still resolves.
- Added one paragraph: it has been a REC since December 2021, W3C republishes it as an amended REC several times a year, so read the undated `/TR/html-aria/` URL and the spec's own change log rather than a snapshot.
- Bumped `updated`.

## Why now

W3C published a new amended Recommendation of ARIA in HTML on **11 August 2026** — `https://www.w3.org/TR/2026/REC-html-aria-20260811/`. That is the second revision since the date this page pinned, which is what surfaced the underlying error.

The [publication history](https://www.w3.org/standards/history/html-aria/) shows: first Recommendation **9 December 2021**, then amended Recommendations on 27 Sep 2022, 21 Dec 2022, through 2023–2025, then 7 April 2026, 15 April 2026, and 11 August 2026. April 2026 was one republication among many, not the date it reached REC.

## Primary source

- [ARIA in HTML](https://www.w3.org/TR/html-aria/) — W3C, latest edition 11 August 2026
- [Publication history](https://www.w3.org/standards/history/html-aria/) — W3C

## Status

Unchanged — `recommended`. Nothing normative moved; this is a factual correction plus a durability fix so the citation stops rotting every few months.

## Changelog

**No entry, deliberately — flagging for a call.** This corrects a factual claim rather than changing what the spec says, which reads as "not loggable" under `CLAUDE.md`. The wrinkle is that the existing entry [`2026-07-31-aria-in-html`](https://specification.website/changelog/) repeats the same wrong date in public. Happy to add a short `changed` entry correcting the record if you'd prefer that over leaving it.

## Checks

`npm run build`, `npm run lint`, `npm run format:check` all pass. No page count or category change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)