### PR TITLE
fix(mcp page): /mcp advertised the 2025-03-26 revision, the endpoint serves 2026-07-28

### DIFF
--- a/src/pages/mcp.astro
+++ b/src/pages/mcp.astro
@@ -39,8 +39,10 @@ const claudeJson = JSON.stringify(desktopConfig, null, 2);
     <article class="prose-spec mt-8">
       <h2 id="endpoint">Endpoint</h2>
       <p>
-        Streamable HTTP MCP, 2025-03-26 protocol revision. Stateless. Wide-open
-        CORS. No authentication.
+        Streamable HTTP MCP, 2026-07-28 protocol revision. Stateless. Wide-open
+        CORS. No authentication. The handshake-based revisions 2025-11-25,
+        2025-06-18 and 2025-03-26 are still answered via <code>initialize</code
+        >, under a published <code>Deprecation</code> and <code>Sunset</code>.
       </p>
       <pre><code>{site.mcp.endpoint}</code></pre>
       <p>
@@ -118,9 +120,9 @@ const claudeJson = JSON.stringify(desktopConfig, null, 2);
 
       <h2 id="connect-other">Other MCP clients</h2>
       <p>
-        Any client that speaks Streamable HTTP MCP (2025-03-26 revision)
-        connects with one URL. There is no client SDK to install and no token to
-        manage. <a
+        Any client that speaks Streamable HTTP MCP (2026-07-28 revision, or one
+        of the older handshake-based revisions above) connects with one URL.
+        There is no client SDK to install and no token to manage. <a
           href="https://github.com/modelcontextprotocol/inspector"
           rel="external">MCP Inspector</a
         > is the fastest way to poke at the schema.


### PR DESCRIPTION
## What changed

`src/pages/mcp.astro` claimed the endpoint speaks the **2025-03-26** protocol revision, in two places (the `#endpoint` paragraph and the "Other MCP clients" paragraph). It does not. Both now name **2026-07-28**, and the endpoint paragraph says explicitly that the three handshake-based revisions are still answered via `initialize` under the published `Deprecation` / `Sunset`.

## Why now

The daily standards scan checked the MCP specification's own versioning page and confirmed **2026-07-28** is the Current revision. Every other surface in this repo already agrees:

- `mcp/src/index.ts` — `const PROTOCOL_VERSION = '2026-07-28'`; `LEGACY_PROTOCOL_VERSIONS = ['2025-11-25', '2025-06-18', '2025-03-26']`.
- `public/.well-known/mcp/server-card.json` — `"protocolVersion": "2026-07-28"`.
- `public/.well-known/agent-skills/specification-website/SKILL.md` — same, and `check:skill` enforces it.
- `/spec/agent-readiness/mcp-and-tool-discovery/` — already documents the handshake removal in 2026-07-28.

So `/mcp` was the one page left advertising the *oldest* revision the Worker tolerates as the one it serves. An agent reading the human page and the server card got two different answers.

## Source

- [MCP — Versioning](https://modelcontextprotocol.io/specification/versioning): "The **current** protocol version is **2026-07-28**."

## Status

No spec-page status is touched. No changelog entry: per `CLAUDE.md`, the changelog covers what the spec *says*, and this is a correction to site plumbing that is invisible on any spec page.

`npm run build`, `npm run lint`, `npm run format:check` and `npm run check:skill` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
