### PR TITLE
add(considered): /.well-known/cyclic-trigger is a control-plane RPC, not a website property

### DIFF
--- a/src/content/considered/cyclic-trigger.md
+++ b/src/content/considered/cyclic-trigger.md
@@ -1,0 +1,24 @@
+---
+title: "/.well-known/cyclic-trigger"
+date: "2026-08-19"
+reason: out-of-scope
+revisit: "Evidence that this is something public sites publish for callers they do not already control, rather than a private hook between an orchestrator and its own services — and an error model that uses HTTP status codes. Both would have to change; adoption alone would not move it."
+sources:
+  - title: "Well-Known URIs registry"
+    url: "https://www.iana.org/assignments/well-known-uris/well-known-uris.xhtml"
+    publisher: "IANA"
+  - title: "Cyclic Trigger specification"
+    url: "https://github.com/SmartStandards/.well-known.cyclic-trigger"
+    publisher: "SmartStandards Community"
+  - title: "RFC 8615 — Well-Known Uniform Resource Identifiers (URIs)"
+    url: "https://www.rfc-editor.org/rfc/rfc8615.html"
+    publisher: "IETF"
+---
+
+IANA registered `cyclic-trigger` as a provisional well-known URI suffix on 17 August 2026. The idea behind it is a reasonable one for a certain kind of deployment: rather than every service keeping a timer or a background worker alive, a service exposes `/.well-known/cyclic-trigger/go`, and external infrastructure POSTs an empty JSON object to it on whatever schedule the ecosystem decides. The trigger carries no parameters at all — it says only "here is an opportunity to run", and the receiving service decides for itself whether anything happens. In a serverless estate where idle workers cost money, that is a sensible inversion.
+
+It is not, however, a property of a website. Nothing a visitor, a crawler or an agent does is affected by whether this endpoint exists, and nobody outside the operator's own control plane is meant to call it. The `/.well-known/` prefix makes it look like the discovery documents this spec normally covers — [security.txt](/spec/security/security-txt/), [the api-catalog](/spec/well-known/api-catalog/), [an agent card](/spec/agent-readiness/a2a-agent-cards/) — but those are files a third party fetches to learn something about the site. This is a remote procedure call that happens to have a fixed name, addressed by infrastructure that already knows the service is there. Registering a suffix reserves a path; it does not make what lives at that path a website concern, and [the well-known overview](/spec/well-known/well-known-overview/) is where that distinction is drawn.
+
+The second problem would keep it out even if the first went away. The specification requires that failures return `200 OK` with a `fault` property in the body, explicitly to spare orchestrators from transport-level error handling. That is the [soft-404](/spec/seo/soft-404/) antipattern — which this spec marks `avoid` — generalised from one status code to all of them, and it contradicts what [error pages](/spec/resilience/error-pages/) says about signalling failure in the status line where every intermediary can see it. We would be recommending a convention that teaches the opposite of a page we already publish.
+
+Adoption does not rescue it either. The registered reference is a two-commit GitHub repository created on 23 June 2026 and untouched since, with no stars, forks, watchers or issues, no named implementers, and no security section for an endpoint whose entire purpose is to make a service perform work on an unauthenticated POST. This entry is our reference case for a narrower rule than the usual one about adoption: a `/.well-known/` name is not automatically a website property. Some registrations are private machinery wearing a public prefix.

--- a/src/content/considered/cyclic-trigger.md
+++ b/src/content/considered/cyclic-trigger.md
@@ -1,6 +1,6 @@
 ---
 title: "/.well-known/cyclic-trigger"
-date: "2026-08-19"
+date: "2026-08-21"
 reason: out-of-scope
 revisit: "Evidence that this is something public sites publish for callers they do not already control, rather than a private hook between an orchestrator and its own services — and an error model that uses HTTP status codes. Both would have to change; adoption alone would not move it."
 sources:


### PR DESCRIPTION
## What changed

One new entry in `src/content/considered/` — `/.well-known/cyclic-trigger`, registered with IANA as a **provisional** well-known URI suffix on **17 August 2026** (change controller: SmartStandards Community). No spec page, no changelog entry, no derived surfaces affected.

## Why now

It is the only registry movement in this run's window. The suffix reserves `/.well-known/cyclic-trigger/go`: a POST with an empty JSON body that lets external infrastructure periodically wake a service which would otherwise keep a background worker or timer alive. Sensible enough for a cost-sensitive serverless estate — and not a website property.

## Why it was turned down

Two independent reasons, either of which is sufficient:

1. **Scope.** Nothing a visitor, crawler or agent does is affected by whether the endpoint exists, and the only caller is the operator's own orchestrator. It is an RPC entry point with a fixed name, not a discovery document a third party fetches to learn something about the site. Reserving a suffix reserves a path; it does not make what lives there a website concern.
2. **It contradicts a page we already publish.** The specification requires that *errors* return `200 OK` with a `fault` property in the body, deliberately, so orchestrators need no transport-level error handling. That is the [soft-404](https://specification.website/spec/seo/soft-404/) antipattern — which this spec marks `avoid` — generalised from one status code to all of them, and it cuts against [error pages](https://specification.website/spec/resilience/error-pages/).

Adoption does not argue the other way: the registered reference is a two-commit GitHub repository created 23 June 2026 and untouched since — 0 stars, 0 forks, 0 watchers, 0 issues, no named implementers, and no security or authentication section for an endpoint whose purpose is to make a service do work on an unauthenticated POST.

`revisit` is deliberately strict: adoption alone would not move this. It would need to become something public sites publish for callers they do not control **and** to start signalling failure in the status line.

## Reference case

This entry carries a narrower rule than the usual adoption one, which the register did not yet state: **a `/.well-known/` name is not automatically a website property.** Some registrations are private machinery wearing a public prefix. It sits alongside #178 (`scitt-keys`) and #157 (`webhook-authorized-senders`) rather than duplicating them — those turn on infrastructure scope and on IANA permanence not being adoption.

## Sources

- [Well-Known URIs registry](https://www.iana.org/assignments/well-known-uris/well-known-uris.xhtml) — IANA
- [Cyclic Trigger specification](https://github.com/SmartStandards/.well-known.cyclic-trigger) — SmartStandards Community
- [RFC 8615 — Well-Known URIs](https://www.rfc-editor.org/rfc/rfc8615.html) — IETF

## Checks

`npm run build`, `npm run lint`, `npm run format:check` all pass; `check:skill` clean (page count unchanged at 168).

🤖 Generated with [Claude Code](https://claude.com/claude-code)