### PR TITLE
add(considered): /.well-known/xregistry is a registry server's URI, not a website's

### DIFF
--- a/src/content/considered/xregistry.md
+++ b/src/content/considered/xregistry.md
@@ -1,0 +1,22 @@
+---
+title: "/.well-known/xregistry"
+date: "2026-08-21"
+reason: out-of-scope
+revisit: "The document moving from the registry server to the site. If the specification — or a consumer of it — starts expecting an ordinary content origin to answer /.well-known/xregistry, rather than the registry service itself, the file becomes something a website publishes and earns a page."
+sources:
+  - title: "Well-Known URIs registry"
+    url: "https://www.iana.org/assignments/well-known-uris/well-known-uris.xhtml"
+    publisher: "IANA"
+  - title: "xRegistry specifications"
+    url: "https://github.com/xregistry/spec"
+    publisher: "xRegistry (CNCF Serverless WG)"
+  - title: "xRegistry"
+    url: "https://www.cncf.io/projects/xregistry/"
+    publisher: "Cloud Native Computing Foundation"
+---
+
+xRegistry — "extensible registry" — is a CNCF Serverless Working Group project, a sibling of CloudEvents built largely by the same people. It "defines an abstract model for how to manage metadata about resources and provides a REST-based interface for creating, modifying, deleting and discovering of those resources", with three concrete registries layered on that model: schemas, message definitions, and messaging endpoints. The core specification and all three domain specifications sit at v1.0-rc4. The `xregistry` suffix was added to the IANA Well-Known URIs registry on 19 August 2026, with the xRegistry Authors as change controller.
+
+It did not land here because of whose origin is expected to answer. The well-known URIs this spec covers — [`security.txt`](/spec/security/security-txt/), [`change-password`](/spec/well-known/change-password/), [`api-catalog`](/spec/well-known/api-catalog/) — are published by the site a person or a crawler visits, and a site is better or worse for serving them. `/.well-known/xregistry` is answered by a registry server: a piece of messaging infrastructure whose clients are other services, discovering event schemas and endpoints. A content site that never serves it is not thereby a worse website, and there is no visitor, crawler, or agent outcome to phrase a "Why it matters" around. That the specification is still at release candidate is a second reason to wait, but not the operative one — a 1.0 would not change the scope argument.
+
+This is the third registration in a month to fail the same test, after `/.well-known/scitt-keys` and `/.well-known/cyclic-trigger`, so treat it as the reference case for the general rule rather than one more instance: **the Well-Known URIs registry is not a to-do list for websites.** It is a namespace shared by everything that speaks HTTP, and much of what lands in it belongs to servers that no one browses. Before a suffix earns a page here, ask which host is meant to serve it. If the answer is "an API gateway", "a registry", or "a control plane", it is out of scope no matter how permanent the registration or how healthy the standards body behind it.


### PR DESCRIPTION
## What changed

Adds one entry to `src/content/considered/` (rendered at `/considered/`) recording why `/.well-known/xregistry` does not get a spec page. No spec pages, no derived surfaces, no SKILL.md change (page count and categories are unchanged).

## Why now

Found by the daily standards scan (2026-08-21). IANA's [Well-Known URIs registry](https://www.iana.org/assignments/well-known-uris/well-known-uris.xhtml) gained the `xregistry` suffix on **2026-08-19**, change controller "xRegistry Authors", reference "xRegistry core v1 specs".

## Primary sources

- [IANA Well-Known URIs registry](https://www.iana.org/assignments/well-known-uris/well-known-uris.xhtml) — the registration itself
- [github.com/xregistry/spec](https://github.com/xregistry/spec) — core + endpoint + message-definitions + schema registries, all at **v1.0-rc4**
- [CNCF: xRegistry](https://www.cncf.io/projects/xregistry/) — Sandbox project, CNCF Serverless WG, sibling of CloudEvents

## Reason: `out-of-scope`

The test is which host is expected to answer. `security.txt`, `change-password` and `api-catalog` are served by the site a person or crawler visits, and a site is better or worse for serving them. `/.well-known/xregistry` is served by a metadata registry for messaging and eventing infrastructure, whose clients are other services. A content site that never serves it is not a worse website, and the "Why it matters" cannot be phrased in terms of visitors, crawlers, or agents.

That the specs are still at release candidate is a second reason to wait, but not the operative one — a 1.0 would not change the scope argument, which is why `reason` is `out-of-scope` rather than `too-early`.

`revisit`: the document moving from the registry server to the site — i.e. the spec or a consumer starting to expect an ordinary content origin to answer it.

## Note on the third-in-a-row framing

This is the third registration in a month to fail the same test, after `/.well-known/scitt-keys` (#178) and `/.well-known/cyclic-trigger` (#184), both still open drafts. Rather than write a third near-identical entry, this one states the general rule — *the Well-Known URIs registry is not a to-do list for websites* — and is positioned as the reference case for it. **If you would rather consolidate all three into one entry, say so and I will rework them.**

## Verification limits

`raw.githubusercontent.com`, `xregistry.io` and `cncf.io` were unreachable from the scan sandbox, so the entry makes **no claim about the contents of the `/.well-known/xregistry` document itself** — only about what xRegistry is and whose origin serves it, both of which are sourced from the repository README and the CNCF project listing. The scope argument does not depend on the file's contents.

`npm run build` passes (168 pages, unchanged). Draft — not for merge without your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)