### PR TITLE
add(considered): vacation-rental.json has limited independent adoption

### DIFF
--- a/src/content/considered/vacation-rental-json.md
+++ b/src/content/considered/vacation-rental-json.md
@@ -1,0 +1,22 @@
+---
+title: "/.well-known/vacation-rental.json"
+date: "2026-09-05"
+reason: too-early
+revisit: "Someone using it. A booking platform, channel manager, or property-management system that publishes the file, or a consumer that fetches it — plus a specification past v0.1 with an implementers list. Adoption is the whole question here; scope is not in doubt."
+sources:
+  - title: "Well-Known URIs registry"
+    url: "https://www.iana.org/assignments/well-known-uris/well-known-uris.xhtml"
+    publisher: "IANA"
+  - title: "Well-Known Uniform Resource Identifiers (URIs)"
+    url: "https://www.rfc-editor.org/rfc/rfc8615.html"
+    publisher: "IETF"
+  - title: "So You Want To Define a Well-Known URI"
+    url: "https://mnot.net/blog/2026/well_known_uris"
+    publisher: "Mark Nottingham"
+---
+
+`vacation-rental.json` was added to the IANA Well-Known URIs registry on 19 August 2026, as a **provisional** entry pointing at a v0.1 document on `vacationrentalprotocol.com` and naming an individual as change controller. The stated purpose is discovery and configuration for vacation-rental applications: a holiday-let site would publish the file so that booking software could find out how to talk to it.
+
+Unusually for a turn-down here, the scope test passes cleanly. This is not another piece of infrastructure that happens to speak HTTP — it is a file an ordinary content origin would serve, in the same shape as [`api-catalog`](/spec/well-known/api-catalog/) or [`nodeinfo`](/spec/well-known/nodeinfo/), and a vacation-rental site that published it would be a slightly better-behaved one. It failed the other test instead: **adoption**. We could find no implementation, no consumer, and no third-party discussion of the format anywhere — the registration and the specification document appear to be the entire public footprint. The document itself was not reachable from the environment this scan runs in, so everything above is drawn from the registry entry rather than from the specification.
+
+That combination — a website-shaped idea with nothing yet using it — is what `too-early` is for, and it is worth separating from the pile of `out-of-scope` registry entries this register has accumulated. A provisional registration is a claim on a name, not evidence that anyone answered the call; the registry records intent, and intent is not deployment. Mark Nottingham's guidance on defining well-known URIs makes the adjacent point that designers reach for the `/.well-known/` prefix partly because it makes a protocol look official — which is a good reason to read a fresh registration as an aspiration rather than a fact about the web. If a page here recommended `vacation-rental.json` today, it would be recommending that sites publish a file no software reads.

--- a/src/content/considered/vacation-rental-json.md
+++ b/src/content/considered/vacation-rental-json.md
@@ -1,8 +1,8 @@
 ---
 title: "/.well-known/vacation-rental.json"
-date: "2026-09-05"
+date: "2026-09-11"
 reason: too-early
-revisit: "Someone using it. A booking platform, channel manager, or property-management system that publishes the file, or a consumer that fetches it — plus a specification past v0.1 with an implementers list. Adoption is the whole question here; scope is not in doubt."
+revisit: "Independent implementations publishing and consuming the format beyond the project's own reference implementation, with documented interoperability. Scope is not in doubt; broader adoption is the missing evidence."
 sources:
   - title: "Well-Known URIs registry"
     url: "https://www.iana.org/assignments/well-known-uris/well-known-uris.xhtml"
@@ -10,13 +10,16 @@ sources:
   - title: "Well-Known Uniform Resource Identifiers (URIs)"
     url: "https://www.rfc-editor.org/rfc/rfc8615.html"
     publisher: "IETF"
-  - title: "So You Want To Define a Well-Known URI"
-    url: "https://mnot.net/blog/2026/well_known_uris"
-    publisher: "Mark Nottingham"
+  - title: "Vacation Rental Protocol — reference implementation and adoption"
+    url: "https://vacationrentalprotocol.com/"
+    publisher: "Vacation Rental Protocol"
+  - title: "Villa Åkerlyckan — live host discovery document"
+    url: "https://villaakerlyckan.se/.well-known/vacation-rental.json"
+    publisher: "Villa Åkerlyckan"
 ---
 
 `vacation-rental.json` was added to the IANA Well-Known URIs registry on 19 August 2026, as a **provisional** entry pointing at a v0.1 document on `vacationrentalprotocol.com` and naming an individual as change controller. The stated purpose is discovery and configuration for vacation-rental applications: a holiday-let site would publish the file so that booking software could find out how to talk to it.
 
-Unusually for a turn-down here, the scope test passes cleanly. This is not another piece of infrastructure that happens to speak HTTP — it is a file an ordinary content origin would serve, in the same shape as [`api-catalog`](/spec/well-known/api-catalog/) or [`nodeinfo`](/spec/well-known/nodeinfo/), and a vacation-rental site that published it would be a slightly better-behaved one. It failed the other test instead: **adoption**. We could find no implementation, no consumer, and no third-party discussion of the format anywhere — the registration and the specification document appear to be the entire public footprint. The document itself was not reachable from the environment this scan runs in, so everything above is drawn from the registry entry rather than from the specification.
+The scope test passes: this is a file an ordinary content origin would serve, like [`api-catalog`](/spec/well-known/api-catalog/) or [`nodeinfo`](/spec/well-known/nodeinfo/). There is also an implementation. The project documents a live reference implementation running on HemmaBo, and Villa Åkerlyckan's [discovery endpoint](https://villaakerlyckan.se/.well-known/vacation-rental.json) returned JSON when checked on 11 September 2026. That confirms publication of the file; it does not establish interoperability with independent booking software.
 
-That combination — a website-shaped idea with nothing yet using it — is what `too-early` is for, and it is worth separating from the pile of `out-of-scope` registry entries this register has accumulated. A provisional registration is a claim on a name, not evidence that anyone answered the call; the registry records intent, and intent is not deployment. Mark Nottingham's guidance on defining well-known URIs makes the adjacent point that designers reach for the `/.well-known/` prefix partly because it makes a protocol look official — which is a good reason to read a fresh registration as an aspiration rather than a fact about the web. If a page here recommended `vacation-rental.json` today, it would be recommending that sites publish a file no software reads.
+The remaining reason for `too-early` is limited independent adoption. The project's own site invites implementers to become its second independent node, and we have not found evidence of broader publishing and consumption beyond that reference implementation. A provisional registration and a working example justify watching the format. Independent implementations demonstrating that they can exchange and use the document would justify revisiting a recommendation.


### PR DESCRIPTION
Records `/.well-known/vacation-rental.json` as `too-early` because independent adoption remains limited. The entry acknowledges the project's HemmaBo reference implementation and the live Villa Åkerlyckan discovery document, verified to return JSON on 11 September 2026.

The revisit criterion is documented interoperability between independent publishers and consumers. The entry cites both the IANA registration and implementation evidence; it does not claim that no implementation exists.

Validation: Astro build, ESLint, formatting, Agent Skill integrity and diff checks pass locally. This change only updates the considered entry; dependency and CI remediation remain separate.
