### PR TITLE
fix(mcp): support npm 10 dependency installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,30 @@ permissions:
   contents: read
 
 jobs:
+  mcp:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mcp
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: mcp/package-lock.json
+
+      - name: Install MCP dependencies
+        run: npm ci
+
+      - name: Audit MCP dependencies
+        run: npm audit
+
+      - name: Generate MCP data and type-check
+        run: npm run build:data && npm run typecheck
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -20,8 +20,6 @@
     "yaml": "^2.6.0"
   },
   "overrides": {
-    "miniflare": {
-      "sharp": "^0.35.4"
-    }
+    "sharp": "^0.35.4"
   }
 }


### PR DESCRIPTION
The MCP deployment after #209 failed during `npm ci`: npm 10.9.8 did not apply the nested Miniflare/Sharp override consistently with the committed lockfile. Local validation had used npm 11, so it missed the deployment failure.

Moves the existing Sharp override to the MCP package level. Sharp is only used by Miniflare in this dependency tree, and the resolved packages and lockfile remain unchanged. Adds a Node 22 MCP CI job for clean installation, auditing, data generation, and type checking so the deployment's installation path runs before merging.

Reproduced the original lockfile error with npm 10.9.8; the corrected package passes a clean install with the same version, reports zero audit vulnerabilities, and passes data generation and type checking.
