### PR TITLE
add(considered): AGENTS.md is a repository convention, not a website one

### DIFF
--- a/src/content/considered/agents-md.md
+++ b/src/content/considered/agents-md.md
@@ -1,0 +1,22 @@
+---
+title: "AGENTS.md"
+date: "2026-09-12"
+reason: out-of-scope
+revisit: "A served form of the convention — agents.md describing a path an origin answers, or consumers fetching AGENTS.md over HTTP from a site they never cloned. Adoption is not the open question here; direction is."
+sources:
+  - title: "AGENTS.md"
+    url: "https://agents.md/"
+    publisher: "AGENTS.md (Agentic AI Foundation)"
+  - title: "agentsmd/agents.md on GitHub"
+    url: "https://github.com/agentsmd/agents.md"
+    publisher: "AGENTS.md"
+  - title: "Linux Foundation Announces the Formation of the Agentic AI Foundation"
+    url: "https://www.linuxfoundation.org/press/linux-foundation-announces-the-formation-of-the-agentic-ai-foundation"
+    publisher: "Linux Foundation"
+---
+
+AGENTS.md is a plain Markdown file at the root of a repository that tells a coding agent how to work on that codebase: build commands, test commands, style rules, the conventions a README leaves out because human contributors absorb them by osmosis. The format was published in August 2025 out of work across OpenAI Codex, Google's Jules, Cursor, Amp and Factory, and is now stewarded by the Agentic AI Foundation under the Linux Foundation, alongside the Model Context Protocol. More than 60,000 open-source projects carry one and more than twenty coding tools read it. Against the adoption bar this register normally applies, it passes comfortably — which is precisely why it needs an entry rather than silence.
+
+It does not land here because nobody serves it. Every agent-readiness topic in this spec — [llms.txt](/spec/agent-readiness/llms-txt/), [Agent Skills discovery](/spec/agent-readiness/agent-skills-discovery/), [A2A agent cards](/spec/agent-readiness/a2a-agent-cards/), [Markdown source endpoints](/spec/agent-readiness/markdown-source-endpoints/) — describes something an origin answers over HTTP to an agent that arrived from outside and knows nothing about you. AGENTS.md runs the other way: instructions that travel with the source, to an agent that already holds a working copy. A website is neither better nor worse for the file existing, and there is no URL to check, which is the test that decides these cases.
+
+The boundary is worth naming rather than assuming, because the website-side equivalent exists and is easy to confuse with this one. Agent Skills discovery is the same instinct pointed outward — a `SKILL.md` that teaches an agent how to use the site, indexed at a well-known URI with a digest so a client can find and verify it without cloning anything. If you want the benefit of AGENTS.md for the agents that visit you rather than the ones that check you out, that is the page to read. Whether a given *repository* should carry an AGENTS.md is a real question, and a good one; it is simply a question about a codebase, not about a website.


### PR DESCRIPTION
## What changed

Adds `src/content/considered/agents-md.md` — one entry in the public [`/considered/`](https://specification.website/considered/) register. No spec page, no changelog entry, no derived surfaces touched.

## Why now

Today's standards scan picked it up through the Agentic AI Foundation thread: A2A moved into AAIF on 17 August 2026, and AAIF's anchoring contributions are MCP, `goose` and **AGENTS.md**. The spec covers MCP and A2A and says nothing at all about AGENTS.md, which is now the odd silence — this is a spec about agent-readiness, and AGENTS.md is the single most widely adopted agent-facing Markdown convention there is.

It comfortably clears the adoption bar (60,000+ repositories, 20+ coding tools). Turning it down on adoption grounds would be wrong; turning it down silently would leave readers guessing. So: an entry, with the actual reason.

## The reason — `out-of-scope`

Nobody serves it. Every agent-readiness topic in this spec describes something an **origin answers over HTTP** to an agent that arrived from outside and knows nothing about the site — llms.txt, Agent Skills discovery, A2A agent cards, Markdown source endpoints. AGENTS.md runs the other way: instructions that travel with the source, read by an agent that already holds a working copy. There is no URL to check, and a website is neither better nor worse for the file existing.

The entry also names [Agent Skills discovery](https://specification.website/spec/agent-readiness/agent-skills-discovery/) as the website-side equivalent, because the two are the same instinct pointed in opposite directions and are easy to confuse.

`revisit`: a served form of the convention — `agents.md` describing a path an origin answers, or consumers fetching AGENTS.md over HTTP from a site they never cloned. Direction is the open question, not adoption.

## Sources

- <https://agents.md/> — the format
- <https://github.com/agentsmd/agents.md> — the repository
- <https://www.linuxfoundation.org/press/linux-foundation-announces-the-formation-of-the-agentic-ai-foundation> — AAIF formation, with AGENTS.md as an anchoring contribution

**Verification caveat:** the scan sandbox blocked direct fetches to `agents.md` and `linuxfoundation.org`, so these three URLs were confirmed via search-index results (title + URL returned live) rather than a direct `GET`. Worth a click before merge.

## Checks

- `npm run build` passes (170 pages, Pagefind index clean).
- `npm run format:check` clean; pre-commit hook (eslint, prettier, skill-drift) passed — SKILL.md still agrees at 170 pages / 10 categories.
- No spec page count change, so no OG regeneration and no `sign:skill` needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
